### PR TITLE
add sugardrive and helper methods

### DIFF
--- a/pkg/chain/message.go
+++ b/pkg/chain/message.go
@@ -53,7 +53,6 @@ type MessageFactory interface {
 // Actual message construction is delegated to a `MessageFactory`, and the message are opaque to the producer.
 type MessageProducer struct {
 	factory       MessageFactory
-	messages      []interface{}
 	accountNonces map[state.Address]uint64
 }
 
@@ -65,44 +64,38 @@ func NewMessageProducer(factory MessageFactory) *MessageProducer {
 	}
 }
 
-// Messages returns a slice containing all messages created by the producer.
-func (mp *MessageProducer) Messages() []interface{} {
-	return mp.messages[:]
-}
-
-// Build creates and stores a single message.
+// Build creates a single message and returns it.
 func (mp *MessageProducer) Build(from, to state.Address, method MethodID, nonce uint64, value, gasPrice state.AttoFIL, gasLimit state.GasUnit,
-	params ...interface{}) error {
+	params ...interface{}) (interface{}, error) {
 	fm, err := mp.factory.MakeMessage(from, to, method, nonce, value, gasPrice, gasLimit, params)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	mp.messages = append(mp.messages, fm)
-	return nil
+	return fm, nil
 }
 
 //
 // Sugar methods for type-checked construction of specific messages.
 //
 
-// Transfer builds a simple value transfer message.
-func (mp *MessageProducer) Transfer(from, to state.Address, value, gasPrice state.AttoFIL, gasLimit state.GasUnit) error {
+// Transfer builds a simple value transfer message and returns it.
+func (mp *MessageProducer) Transfer(from, to state.Address, value, gasPrice state.AttoFIL, gasLimit state.GasUnit) (interface{}, error) {
 	nonce := mp.accountNonces[from]
 	mp.accountNonces[from]++
 	return mp.Build(from, to, NoMethod, nonce, value, gasPrice, gasLimit)
 }
 
-// InitExec builds a message invoking InitActor.Exec
-func (mp *MessageProducer) InitExec(from state.Address, value, gasPrice state.AttoFIL, gasLimit state.GasUnit, params ...interface{}) error {
+// InitExec builds a message invoking InitActor.Exec and returns it.
+func (mp *MessageProducer) InitExec(from state.Address, value, gasPrice state.AttoFIL, gasLimit state.GasUnit, params ...interface{}) (interface{}, error) {
 	nonce := mp.accountNonces[from]
 	mp.accountNonces[from]++
 	return mp.Build(state.InitAddress, from, InitExec, nonce, value, gasPrice, gasLimit, params)
 }
 
-// StoragePowerCreateStorageMiner builds a message invoking StoragePowerActor.CreateStorageMiner
+// StoragePowerCreateStorageMiner builds a message invoking StoragePowerActor.CreateStorageMiner and returns it.
 func (mp *MessageProducer) StoragePowerCreateStorageMiner(from state.Address, value, gasPrice state.AttoFIL, gasLimit state.GasUnit,
-	owner state.Address, worker state.PubKey, sectorSize state.BytesAmount, peerID state.PeerID) error {
+	owner state.Address, worker state.PubKey, sectorSize state.BytesAmount, peerID state.PeerID) (interface{}, error) {
 	nonce := mp.accountNonces[from]
 	mp.accountNonces[from]++
 	return mp.Build(state.StorageMarketAddress, from, StoragePowerCreateStorageMiner, nonce, value, gasPrice, gasLimit, owner, worker, sectorSize, peerID)

--- a/pkg/chain/validator.go
+++ b/pkg/chain/validator.go
@@ -39,16 +39,6 @@ func NewValidator(executor Applier) *Validator {
 
 // ApplyMessages applies a sequence of message to a state.
 // The resulting state is return. The storage is modified in place.
-func (v *Validator) ApplyMessages(context *ExecutionContext, tree state.Tree, storage state.StorageMap, messages []interface{}) (state.Tree, []MessageReceipt, error) {
-	var err error
-	var receipts []MessageReceipt
-	for _, m := range messages {
-		var mr MessageReceipt
-		tree, mr, err = v.applier.ApplyMessage(tree, storage, context, m)
-		receipts = append(receipts, mr)
-		if err != nil {
-			return nil, nil, err
-		}
-	}
-	return tree, receipts, nil
+func (v *Validator) ApplyMessage(context *ExecutionContext, tree state.Tree, storage state.StorageMap, message interface{}) (state.Tree, MessageReceipt, error) {
+	return v.applier.ApplyMessage(tree, storage, context, message)
 }

--- a/pkg/state/actors.go
+++ b/pkg/state/actors.go
@@ -10,6 +10,7 @@ var (
 	InitActorCodeCid          cid.Cid
 	AccountActorCodeCid       cid.Cid
 	StorageMarketActorCodeCid cid.Cid
+	StorageMinerActorCodeCid  cid.Cid
 )
 
 // Builtin actor addresses.
@@ -31,6 +32,9 @@ func init() {
 
 	StorageMarketActorCodeObj := dag.NewRawNode([]byte("storagemarket"))
 	StorageMarketActorCodeCid = StorageMarketActorCodeObj.Cid()
+
+	StorageMinerActorCodeObj := dag.NewRawNode([]byte("storagemarket"))
+	StorageMinerActorCodeCid = StorageMinerActorCodeObj.Cid()
 
 	InitAddress, err = NewIDAddress(0)
 	if err != nil {

--- a/pkg/state/factory.go
+++ b/pkg/state/factory.go
@@ -1,10 +1,12 @@
 package state
 
-import "github.com/ipfs/go-cid"
+import (
+	"github.com/ipfs/go-cid"
+)
 
 // Factory abstracts over the construction of concrete implementation-specific state objects.
 type Factory interface {
 	NewAddress() (Address, error)
 	NewActor(code cid.Cid, balance AttoFIL) Actor
-	NewState(actors map[Address]Actor) (Tree, StorageMap, error)
+	NewState(actors []ActorAndAddress) (Tree, StorageMap, error)
 }

--- a/pkg/state/tree.go
+++ b/pkg/state/tree.go
@@ -22,3 +22,7 @@ type Actor interface {
 	Balance() AttoFIL
 }
 
+type ActorAndAddress struct {
+	Actor   Actor
+	Address Address
+}

--- a/pkg/suites/driver.go
+++ b/pkg/suites/driver.go
@@ -1,8 +1,12 @@
 package suites
 
 import (
+	"math/big"
+	"testing"
+
 	"github.com/filecoin-project/chain-validation/pkg/chain"
 	"github.com/filecoin-project/chain-validation/pkg/state"
+	"github.com/stretchr/testify/require"
 )
 
 // Driver wraps up all the implementation-specific integration points.
@@ -10,4 +14,120 @@ type Driver interface {
 	state.Factory
 	chain.MessageFactory
 	chain.Applier
+}
+
+type SugarDrive struct {
+	t *testing.T
+	Driver
+}
+
+func NewSugarDrive(t *testing.T, driver Driver) *SugarDrive {
+	return &SugarDrive{
+		t:      t,
+		Driver: driver,
+	}
+}
+
+type SugarActor struct {
+	actor   state.Actor
+	address state.Address
+}
+
+func (s *SugarDrive) MakeAccountActor(balance int64) *SugarActor {
+	addr, err := s.NewAddress()
+	require.NoError(s.t, err)
+	actor := s.NewActor(state.AccountActorCodeCid, big.NewInt(balance))
+	return &SugarActor{
+		actor:   actor,
+		address: addr,
+	}
+}
+
+func (s *SugarDrive) MakeStorageMinerActor(owner state.Address, wokerPk []byte, sectorSize uint64) *SugarActor {
+	addr, err := s.NewAddress()
+	require.NoError(s.t, err)
+	actor := s.NewActor(state.StorageMinerActorCodeCid, big.NewInt(0))
+	return &SugarActor{
+		actor:   actor,
+		address: addr,
+	}
+}
+
+func (s *SugarDrive) ProducerWithActors(miner *SugarActor, actors ...*SugarActor) *SugarMessageProducer {
+	var aa []state.ActorAndAddress
+	for _, a := range actors {
+		aa = append(aa, state.ActorAndAddress{
+			Actor:   a.actor,
+			Address: a.address,
+		})
+	}
+	aa = append(aa, state.ActorAndAddress{
+		Actor:   miner.actor,
+		Address: miner.address,
+	})
+	tree, storage, err := s.NewState(aa)
+	require.NoError(s.t, err)
+	require.NotNil(s.t, tree)
+	require.NotNil(s.t, storage)
+
+	gasPrice := big.NewInt(1)
+	gasLimit := state.GasUnit(1000)
+	exeCtx := chain.NewExecutionContext(1, miner.address)
+	validator := chain.NewValidator(s.Driver)
+
+	return &SugarMessageProducer{
+		t:         s.t,
+		producer:  chain.NewMessageProducer(s),
+		exeCtx:    exeCtx,
+		validator: validator,
+
+		tree:    tree,
+		storage: storage,
+		miner:   miner,
+
+		gasPrice: gasPrice,
+		gasLimit: gasLimit,
+	}
+}
+
+type SugarMessageProducer struct {
+	t         *testing.T
+	producer  *chain.MessageProducer
+	exeCtx    *chain.ExecutionContext
+	validator *chain.Validator
+
+	tree    state.Tree
+	storage state.StorageMap
+	miner   *SugarActor
+
+	gasPrice state.AttoFIL
+	gasLimit state.GasUnit
+}
+
+func (s *SugarMessageProducer) Transfer(from, to *SugarActor, amount int64) state.Tree {
+	msg, err := s.producer.Transfer(from.address, to.address, big.NewInt(amount), s.gasPrice, s.gasLimit)
+	require.NoError(s.t, err)
+
+	endState, msgReceipt, err := s.validator.ApplyMessage(s.exeCtx, s.tree, s.storage, msg)
+	require.NoError(s.t, err)
+	require.NotNil(s.t, endState)
+	require.NotNil(s.t, msgReceipt)
+
+	require.Equal(s.t, uint8(0), msgReceipt.ExitCode)
+	require.Equal(s.t, []byte{}, msgReceipt.ReturnValue)
+	require.Equal(s.t, state.GasUnit(0), msgReceipt.GasUsed)
+
+	newFromState, err := endState.Actor(from.address)
+	require.NoError(s.t, err)
+	from.actor = newFromState
+
+	newToState, err := endState.Actor(to.address)
+	require.NoError(s.t, err)
+	to.actor = newToState
+
+	newMinerState, err := endState.Actor(s.miner.address)
+	require.NoError(s.t, err)
+	s.miner.actor = newMinerState
+
+	return endState
 }

--- a/pkg/suites/example.go
+++ b/pkg/suites/example.go
@@ -1,12 +1,7 @@
 package suites
 
 import (
-	"math/big"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
-
-	"github.com/filecoin-project/chain-validation/pkg/state"
 )
 
 // A basic example validation test.
@@ -19,16 +14,6 @@ func Example(t *testing.T, driver Driver) {
 	miner := sugar.MakeStorageMinerActor(alice.address, []byte{1}, 1024)
 	producer := sugar.ProducerWithActors(miner, alice, bob)
 
-	producer.Transfer(alice, bob, 50)
-	assert.Equal(t, state.AttoFIL(big.NewInt(1950)), alice.actor.Balance())
-	assert.Equal(t, state.AttoFIL(big.NewInt(50)), bob.actor.Balance())
-	// This should become non-zero after gas tracking and payments are integrated.
-	assert.Equal(t, state.AttoFIL(big.NewInt(0)), miner.actor.Balance())
-
-	producer.Transfer(alice, bob, 100)
-	assert.Equal(t, state.AttoFIL(big.NewInt(1850)), alice.actor.Balance())
-	assert.Equal(t, state.AttoFIL(big.NewInt(150)), bob.actor.Balance())
-	// This should become non-zero after gas tracking and payments are integrated.
-	assert.Equal(t, state.AttoFIL(big.NewInt(0)), miner.actor.Balance())
-
+	producer.MustTransfer(alice, bob, 50)
+	producer.MustTransfer(alice, bob, 100)
 }

--- a/pkg/suites/example.go
+++ b/pkg/suites/example.go
@@ -5,63 +5,30 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
-	"github.com/filecoin-project/chain-validation/pkg/chain"
 	"github.com/filecoin-project/chain-validation/pkg/state"
 )
 
 // A basic example validation test.
 // At present this code is verbose and demonstrates the opportunity for helper methods.
 func Example(t *testing.T, driver Driver) {
-	actors := make(map[state.Address]state.Actor)
+	sugar := NewSugarDrive(t, driver)
 
-	// TODO this is poor UX, these will maybe need to go somehwere else?
-	gasPrice := big.NewInt(1)
-	gasLimit := state.GasUnit(1000)
+	alice := sugar.MakeAccountActor(2000)
+	bob := sugar.MakeAccountActor(0)
+	miner := sugar.MakeStorageMinerActor(alice.address, []byte{1}, 1024)
+	producer := sugar.ProducerWithActors(miner, alice, bob)
 
-	alice, err := driver.NewAddress()
-	require.NoError(t, err)
-	actors[alice] = driver.NewActor(state.AccountActorCodeCid, big.NewInt(2000))
-
-	bob, err := driver.NewAddress()
-	require.NoError(t, err)
-	actors[bob] = driver.NewActor(state.AccountActorCodeCid, big.NewInt(0))
-
-	miner, err := driver.NewAddress()
-	require.NoError(t, err)
-	actors[miner] = driver.NewActor(state.AccountActorCodeCid, big.NewInt(0))
-
-	tree, storage, err := driver.NewState(actors)
-	require.NoError(t, err)
-	require.NotNil(t, tree)
-	require.NotNil(t, storage)
-
-	producer := chain.NewMessageProducer(driver)
-	msg, err := producer.Transfer(alice, bob, big.NewInt(50), gasPrice, gasLimit)
-
-	exeCtx := chain.NewExecutionContext(1, miner)
-	validator := chain.NewValidator(driver)
-
-	endState, msgReceipt, err := validator.ApplyMessage(exeCtx, tree, storage, msg)
-	require.NoError(t, err)
-	require.NotNil(t, endState)
-	require.NotNil(t, msgReceipt)
-
-	assert.Equal(t, uint8(0), msgReceipt.ExitCode)
-	assert.Equal(t, []byte{}, msgReceipt.ReturnValue)
-	assert.Equal(t, state.GasUnit(0), msgReceipt.GasUsed)
-
-	actorAlice, err := endState.Actor(alice)
-	require.NoError(t, err)
-	assert.Equal(t, state.AttoFIL(big.NewInt(1950)), actorAlice.Balance())
-
-	actorBob, err := endState.Actor(bob)
-	require.NoError(t, err)
-	assert.Equal(t, state.AttoFIL(big.NewInt(50)), actorBob.Balance())
-
+	producer.Transfer(alice, bob, 50)
+	assert.Equal(t, state.AttoFIL(big.NewInt(1950)), alice.actor.Balance())
+	assert.Equal(t, state.AttoFIL(big.NewInt(50)), bob.actor.Balance())
 	// This should become non-zero after gas tracking and payments are integrated.
-	actorMiner, err := endState.Actor(miner)
-	require.NoError(t, err)
-	assert.Equal(t, state.AttoFIL(big.NewInt(0)), actorMiner.Balance())
+	assert.Equal(t, state.AttoFIL(big.NewInt(0)), miner.actor.Balance())
+
+	producer.Transfer(alice, bob, 100)
+	assert.Equal(t, state.AttoFIL(big.NewInt(1850)), alice.actor.Balance())
+	assert.Equal(t, state.AttoFIL(big.NewInt(150)), bob.actor.Balance())
+	// This should become non-zero after gas tracking and payments are integrated.
+	assert.Equal(t, state.AttoFIL(big.NewInt(0)), miner.actor.Balance())
+
 }

--- a/pkg/suites/example.go
+++ b/pkg/suites/example.go
@@ -38,20 +38,19 @@ func Example(t *testing.T, driver Driver) {
 	require.NotNil(t, storage)
 
 	producer := chain.NewMessageProducer(driver)
-	require.NoError(t, producer.Transfer(alice, bob, big.NewInt(50), gasPrice, gasLimit))
+	msg, err := producer.Transfer(alice, bob, big.NewInt(50), gasPrice, gasLimit)
 
 	exeCtx := chain.NewExecutionContext(1, miner)
 	validator := chain.NewValidator(driver)
 
-	endState, msgReceipts, err := validator.ApplyMessages(exeCtx, tree, storage, producer.Messages())
+	endState, msgReceipt, err := validator.ApplyMessage(exeCtx, tree, storage, msg)
 	require.NoError(t, err)
 	require.NotNil(t, endState)
-	require.NotNil(t, msgReceipts)
+	require.NotNil(t, msgReceipt)
 
-	assert.Equal(t, 1, len(msgReceipts))
-	assert.Equal(t, uint8(0), msgReceipts[0].ExitCode)
-	assert.Equal(t, []byte{}, msgReceipts[0].ReturnValue)
-	assert.Equal(t, state.GasUnit(0), msgReceipts[0].GasUsed)
+	assert.Equal(t, uint8(0), msgReceipt.ExitCode)
+	assert.Equal(t, []byte{}, msgReceipt.ReturnValue)
+	assert.Equal(t, state.GasUnit(0), msgReceipt.GasUsed)
 
 	actorAlice, err := endState.Actor(alice)
 	require.NoError(t, err)


### PR DESCRIPTION
A `SugarDrive` is a wrapper around the `Driver` interface. The motivation for its creation was to make test code less verbose.

I have also modified the Factory NewState interface method to accept a slice to that its construction is deterministic.