### PR TITLE
add actor code and singleton address enums

### DIFF
--- a/pkg/chain/message.go
+++ b/pkg/chain/message.go
@@ -48,6 +48,7 @@ const (
 type MessageFactory interface {
 	MakeMessage(from, to state.Address, method MethodID, nonce uint64, value, gasPrice state.AttoFIL, gasLimit state.GasUnit,
 		params ...interface{}) (interface{}, error)
+	FromSingletonAddress(address state.SingletonActorAddress) (state.Address, error)
 }
 
 // MessageProducer presents a convenient API for scripting the creation of long and complex message sequences.
@@ -140,16 +141,24 @@ func (mp *MessageProducer) Transfer(from, to state.Address, nonce uint64, value 
 
 // InitExec builds a message invoking InitActor.Exec and returns it.
 func (mp *MessageProducer) InitExec(from state.Address, nonce uint64, params []interface{}, opts ...MsgOpt) (interface{}, error) {
-	return mp.Build(state.InitAddress, from, nonce, InitExec, params, opts...)
+	iaAddr, err := mp.factory.FromSingletonAddress(state.InitAddress)
+	if err != nil {
+		return nil, err
+	}
+	return mp.Build(iaAddr, from, nonce, InitExec, params, opts...)
 }
 
 // StoragePowerCreateStorageMiner builds a message invoking StoragePowerActor.CreateStorageMiner and returns it.
 func (mp *MessageProducer) StoragePowerCreateStorageMiner(from state.Address, nonce uint64,
 	owner state.Address, worker state.PubKey, sectorSize state.BytesAmount, peerID state.PeerID,
 	opts ...MsgOpt) (interface{}, error) {
+
+	smaAddr, err := mp.factory.FromSingletonAddress(state.StorageMarketAddress)
+	if err != nil {
+		return nil, err
+	}
 	params := []interface{}{owner, worker, sectorSize, peerID}
-	return mp.Build(from, state.StorageMarketAddress, nonce, StoragePowerCreateStorageMiner, params, opts...)
+	return mp.Build(from, smaAddr, nonce, StoragePowerCreateStorageMiner, params, opts...)
 }
 
 var noParams []interface{}
-

--- a/pkg/chain/message.go
+++ b/pkg/chain/message.go
@@ -48,7 +48,7 @@ const (
 type MessageFactory interface {
 	MakeMessage(from, to state.Address, method MethodID, nonce uint64, value, gasPrice state.AttoFIL, gasLimit state.GasUnit,
 		params ...interface{}) (interface{}, error)
-	FromSingletonAddress(address state.SingletonActorAddress) (state.Address, error)
+	FromSingletonAddress(address state.SingletonActorID) state.Address
 }
 
 // MessageProducer presents a convenient API for scripting the creation of long and complex message sequences.
@@ -141,10 +141,7 @@ func (mp *MessageProducer) Transfer(from, to state.Address, nonce uint64, value 
 
 // InitExec builds a message invoking InitActor.Exec and returns it.
 func (mp *MessageProducer) InitExec(from state.Address, nonce uint64, params []interface{}, opts ...MsgOpt) (interface{}, error) {
-	iaAddr, err := mp.factory.FromSingletonAddress(state.InitAddress)
-	if err != nil {
-		return nil, err
-	}
+	iaAddr := mp.factory.FromSingletonAddress(state.InitAddress)
 	return mp.Build(iaAddr, from, nonce, InitExec, params, opts...)
 }
 
@@ -153,10 +150,7 @@ func (mp *MessageProducer) StoragePowerCreateStorageMiner(from state.Address, no
 	owner state.Address, worker state.PubKey, sectorSize state.BytesAmount, peerID state.PeerID,
 	opts ...MsgOpt) (interface{}, error) {
 
-	smaAddr, err := mp.factory.FromSingletonAddress(state.StorageMarketAddress)
-	if err != nil {
-		return nil, err
-	}
+	smaAddr := mp.factory.FromSingletonAddress(state.StorageMarketAddress)
 	params := []interface{}{owner, worker, sectorSize, peerID}
 	return mp.Build(from, smaAddr, nonce, StoragePowerCreateStorageMiner, params, opts...)
 }

--- a/pkg/state/actors.go
+++ b/pkg/state/actors.go
@@ -1,16 +1,16 @@
 package state
 
-type ActorCodeCid int
+type ActorCodeID int
 const (
-	AccountActorCodeCid  = ActorCodeCid(iota)
+	AccountActorCodeCid  = ActorCodeID(iota)
 	StorageMinerCodeCid
 	MultisigActorCodeCid
 	PaymentChannelActorCodeCid
 )
 
-type SingletonActorAddress int
+type SingletonActorID int
 const (
-	InitAddress = SingletonActorAddress(iota)
+	InitAddress = SingletonActorID(iota)
 	NetworkAddress
 	StorageMarketAddress
 	BurntFundsAddress

--- a/pkg/state/actors.go
+++ b/pkg/state/actors.go
@@ -1,51 +1,17 @@
 package state
 
-import (
-	"github.com/ipfs/go-cid"
-	dag "github.com/ipfs/go-merkledag"
+type ActorCodeCid int
+const (
+	AccountActorCodeCid  = ActorCodeCid(iota)
+	StorageMinerCodeCid
+	MultisigActorCodeCid
+	PaymentChannelActorCodeCid
 )
 
-// Builtin actor code CIDs.
-var (
-	InitActorCodeCid          cid.Cid
-	AccountActorCodeCid       cid.Cid
-	StorageMarketActorCodeCid cid.Cid
+type SingletonActorAddress int
+const (
+	InitAddress = SingletonActorAddress(iota)
+	NetworkAddress
+	StorageMarketAddress
+	BurntFundsAddress
 )
-
-// Builtin actor addresses.
-var (
-	InitAddress          Address
-	NetworkAddress       Address
-	StorageMarketAddress Address
-	BurntFundsAddress    Address
-)
-
-func init() {
-	var err error
-
-	InitActorCodeObj := dag.NewRawNode([]byte("initactor"))
-	InitActorCodeCid = InitActorCodeObj.Cid()
-
-	AccountActorCodeObj := dag.NewRawNode([]byte("accountactor"))
-	AccountActorCodeCid = AccountActorCodeObj.Cid()
-
-	StorageMarketActorCodeObj := dag.NewRawNode([]byte("storagemarket"))
-	StorageMarketActorCodeCid = StorageMarketActorCodeObj.Cid()
-
-	InitAddress, err = NewIDAddress(0)
-	if err != nil {
-		panic(err)
-	}
-	NetworkAddress, err = NewIDAddress(1)
-	if err != nil {
-		panic(err)
-	}
-	StorageMarketAddress, err = NewIDAddress(2)
-	if err != nil {
-		panic(err)
-	}
-	BurntFundsAddress, err = NewIDAddress(99)
-	if err != nil {
-		panic(err)
-	}
-}

--- a/pkg/state/wrapper.go
+++ b/pkg/state/wrapper.go
@@ -14,9 +14,13 @@ type Wrapper interface {
 
 	// Creates a new private key and returns the associated address.
 	NewAccountAddress() (Address, error)
+
 	// Installs a new actor in the state tree.
 	// This signature will probably become a little more complex when the actor state is non-empty.
-	SetActor(address Address, code cid.Cid, balance AttoFIL) (Actor, Storage, error)
+	SetActor(address Address, code ActorCodeCid, balance AttoFIL) (Actor, Storage, error)
+
+	// Installs a new singleton actor in the state tree.
+	SetSingletonActor(address SingletonActorAddress, balance AttoFIL) (Actor, Storage, error)
 }
 
 // Actor is an abstraction over the actor states stored in the root of the state tree.

--- a/pkg/state/wrapper.go
+++ b/pkg/state/wrapper.go
@@ -17,10 +17,10 @@ type Wrapper interface {
 
 	// Installs a new actor in the state tree.
 	// This signature will probably become a little more complex when the actor state is non-empty.
-	SetActor(address Address, code ActorCodeCid, balance AttoFIL) (Actor, Storage, error)
+	SetActor(address Address, code ActorCodeID, balance AttoFIL) (Actor, Storage, error)
 
 	// Installs a new singleton actor in the state tree.
-	SetSingletonActor(address SingletonActorAddress, balance AttoFIL) (Actor, Storage, error)
+	SetSingletonActor(address SingletonActorID, balance AttoFIL) (Actor, Storage, error)
 }
 
 // Actor is an abstraction over the actor states stored in the root of the state tree.


### PR DESCRIPTION
### Motivation
Allow different implementations to use different actor codes and singleton actor addresses until spec converges on definitions

### Implementation.
- add SetSingletonActor method to Wrapper interface
- add FromSingletonAddress to message factory interface, required by the sugar methods.