### PR TITLE
[wip] cbor: encode types to cbor array with example test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,9 +7,12 @@ require (
 	github.com/ipfs/go-bitswap v0.1.0 // indirect
 	github.com/ipfs/go-blockservice v0.0.2 // indirect
 	github.com/ipfs/go-cid v0.0.3
-	github.com/ipfs/go-ipld-cbor v0.0.2 // indirect
+	github.com/ipfs/go-ipld-cbor v0.0.2
 	github.com/ipfs/go-ipld-format v0.0.2 // indirect
 	github.com/ipfs/go-merkledag v0.0.2
+	github.com/libp2p/go-libp2p-core v0.0.2
 	github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1
+	github.com/multiformats/go-multihash v0.0.5
+	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.3.0
 )

--- a/go.mod
+++ b/go.mod
@@ -10,9 +10,7 @@ require (
 	github.com/ipfs/go-ipld-cbor v0.0.2
 	github.com/ipfs/go-ipld-format v0.0.2 // indirect
 	github.com/ipfs/go-merkledag v0.0.2
-	github.com/libp2p/go-libp2p-core v0.0.2
 	github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1
-	github.com/multiformats/go-multihash v0.0.5
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.3.0
 )

--- a/pkg/state/types.go
+++ b/pkg/state/types.go
@@ -1,15 +1,47 @@
 package state
 
 import (
+	"github.com/filecoin-project/go-leb128"
+	"github.com/pkg/errors"
 	"math/big"
+
+	cbor "github.com/ipfs/go-ipld-cbor"
 )
 
 // Type aliases for state values and message method parameters.
 type (
 	BytesAmount *big.Int
 	AttoFIL *big.Int
+
 	GasUnit uint64
+
 	PubKey []byte
 	PeerID []byte
 )
 
+// Given a slice of the above types convert them to CBOR byte array.
+func EncodeValues(params ...interface{}) ([]byte, error) {
+	if len(params) == 0 {
+		return []byte{}, nil
+	}
+	var arr [][]byte
+	for i, p := range params {
+		switch v := p.(type) {
+		case Address:
+			arr = append(arr, []byte(v))
+		case AttoFIL:
+			arr = append(arr, (*v).Bytes())
+		case BytesAmount:
+			arr = append(arr, (*v).Bytes())
+		case GasUnit:
+			arr = append(arr, leb128.FromUInt64(uint64(v)))
+		case PubKey:
+			arr = append(arr, v)
+		case PeerID:
+			arr = append(arr, v)
+		default:
+			return []byte{}, errors.Errorf("invalid type: %T at index: %d", p, i)
+		}
+	}
+	return cbor.DumpObject(arr)
+}

--- a/pkg/state/types.go
+++ b/pkg/state/types.go
@@ -1,11 +1,11 @@
 package state
 
 import (
-	"github.com/filecoin-project/go-leb128"
-	"github.com/pkg/errors"
 	"math/big"
 
+	"github.com/filecoin-project/go-leb128"
 	cbor "github.com/ipfs/go-ipld-cbor"
+	"github.com/pkg/errors"
 )
 
 // Type aliases for state values and message method parameters.
@@ -19,29 +19,40 @@ type (
 	PeerID []byte
 )
 
-// Given a slice of the above types convert them to CBOR byte array.
+// Given a slice of the above types encode them to CBOR byte array.
 func EncodeValues(params ...interface{}) ([]byte, error) {
 	if len(params) == 0 {
 		return []byte{}, nil
 	}
 	var arr [][]byte
 	for i, p := range params {
-		switch v := p.(type) {
-		case Address:
-			arr = append(arr, []byte(v))
-		case AttoFIL:
-			arr = append(arr, (*v).Bytes())
-		case BytesAmount:
-			arr = append(arr, (*v).Bytes())
-		case GasUnit:
-			arr = append(arr, leb128.FromUInt64(uint64(v)))
-		case PubKey:
-			arr = append(arr, v)
-		case PeerID:
-			arr = append(arr, v)
-		default:
-			return []byte{}, errors.Errorf("invalid type: %T at index: %d", p, i)
+		bs, err := EncodeValue(p)
+		if err != nil {
+			return []byte{}, errors.Wrapf(err, "failed at index: %d", i)
 		}
+		arr = append(arr, bs)
 	}
 	return cbor.DumpObject(arr)
 }
+
+// Given an above type encode it to CBOR.
+func EncodeValue(p interface{}) ([]byte, error) {
+	switch v := p.(type) {
+	case Address:
+		return []byte(v), nil
+	case AttoFIL:
+		return (*v).Bytes(), nil
+	case BytesAmount:
+		return (*v).Bytes(), nil
+	case GasUnit:
+		return leb128.FromUInt64(uint64(v)), nil
+	case PubKey:
+		return v, nil
+	case PeerID:
+		return v, nil
+	default:
+		return []byte{}, errors.Errorf("invalid type: %T", p)
+	}
+
+}
+

--- a/pkg/state/types_test.go
+++ b/pkg/state/types_test.go
@@ -1,0 +1,45 @@
+package state_test
+
+import (
+	"encoding/binary"
+	"math/big"
+	"testing"
+
+	"github.com/libp2p/go-libp2p-core/peer"
+	mh "github.com/multiformats/go-multihash"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+
+	"github.com/filecoin-project/chain-validation/pkg/state"
+)
+
+func TestExampleEncodeValues(t *testing.T) {
+	owner, err := state.NewActorAddress([]byte{1,2,3,4,5})
+	require.NoError(t, err)
+
+	sectorSize := state.BytesAmount(big.NewInt(10))
+
+	bpid, err := RequireIntPeerID(t, 0).MarshalBinary()
+	require.NoError(t, err)
+
+	peerID := state.PeerID(bpid)
+
+	params := []interface{}{owner, sectorSize, peerID}
+
+	stuff, err := state.EncodeValues(params...)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, stuff)
+}
+
+func RequireIntPeerID(t *testing.T, i int64) peer.ID {
+	buf := make([]byte, 16)
+	n := binary.PutVarint(buf, i)
+	h, err := mh.Sum(buf[:n], mh.ID, -1)
+	require.NoError(t, err)
+	pid, err := peer.IDFromBytes(h)
+	require.NoError(t, err)
+	return pid
+}
+
+

--- a/pkg/state/types_test.go
+++ b/pkg/state/types_test.go
@@ -1,13 +1,10 @@
 package state_test
 
 import (
-	"encoding/binary"
 	"math/big"
 	"testing"
 
 	cbor "github.com/ipfs/go-ipld-cbor"
-	"github.com/libp2p/go-libp2p-core/peer"
-	mh "github.com/multiformats/go-multihash"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -19,11 +16,7 @@ func TestExampleEncodeValues(t *testing.T) {
 	require.NoError(t, err)
 
 	sectorSize := state.BytesAmount(big.NewInt(10))
-
-	bpid, err := RequireIntPeerID(t, 0).MarshalBinary()
-	require.NoError(t, err)
-
-	peerID := state.PeerID(bpid)
+	peerID := state.PeerID([]byte{0,9,8,7,6,5})
 
 	params := []interface{}{owner, sectorSize, peerID}
 	data, err := state.EncodeValues(params...)
@@ -43,19 +36,8 @@ func TestExampleEncodeValues(t *testing.T) {
 	assert.Equal(t, sectorSize, expSectorSize)
 
 	v = arr[2] // peerID
-	bp, err := peer.IDFromBytes(v)
 	require.NoError(t, err)
-	expPeerID := state.PeerID(bp)
+	expPeerID := state.PeerID(v)
 	assert.Equal(t, peerID, expPeerID)
 
-}
-
-func RequireIntPeerID(t *testing.T, i int64) peer.ID {
-	buf := make([]byte, 16)
-	n := binary.PutVarint(buf, i)
-	h, err := mh.Sum(buf[:n], mh.ID, -1)
-	require.NoError(t, err)
-	pid, err := peer.IDFromBytes(h)
-	require.NoError(t, err)
-	return pid
 }


### PR DESCRIPTION
This is a first pass at encoding types to CBOR. Packages that use this testing library should be able to encode messages parameters using `EncodeValues`.