### PR TITLE
Create payment channel test and payment channel actor state interface

### DIFF
--- a/pkg/state/actors.go
+++ b/pkg/state/actors.go
@@ -1,14 +1,16 @@
 package state
 
 type ActorCodeID int
+
 const (
-	AccountActorCodeCid  = ActorCodeID(iota)
+	AccountActorCodeCid = ActorCodeID(iota)
 	StorageMinerCodeCid
 	MultisigActorCodeCid
 	PaymentChannelActorCodeCid
 )
 
 type SingletonActorID int
+
 const (
 	InitAddress = SingletonActorID(iota)
 	NetworkAddress

--- a/pkg/state/types.go
+++ b/pkg/state/types.go
@@ -4,6 +4,7 @@ import (
 	"math/big"
 
 	"github.com/filecoin-project/go-leb128"
+	"github.com/ipfs/go-cid"
 	cbor "github.com/ipfs/go-ipld-cbor"
 	"github.com/pkg/errors"
 )
@@ -11,7 +12,7 @@ import (
 // Type aliases for state values and message method parameters.
 type (
 	BytesAmount *big.Int
-	AttoFIL *big.Int
+	AttoFIL     *big.Int
 
 	GasUnit uint64
 
@@ -52,8 +53,11 @@ func EncodeValue(p interface{}) (interface{}, error) {
 		return v, nil
 	case PeerID:
 		return v, nil
+	case cid.Cid:
+		return v, nil
+	case []interface{}:
+		return EncodeValues(v...)
 	default:
 		return []byte{}, errors.Errorf("invalid type: %T", p)
 	}
 }
-

--- a/pkg/state/wrapper.go
+++ b/pkg/state/wrapper.go
@@ -1,14 +1,21 @@
 package state
 
-import "github.com/ipfs/go-cid"
+import (
+	"github.com/ipfs/go-cid"
+)
 
 // Wrapper abstracts the inspection and mutation of an implementation-specific state tree and storage.
 // The interface wraps a single, mutable state.
 type Wrapper interface {
 	// Returns the CID of the root node of the state tree.
 	Cid() cid.Cid
+
 	// Returns the actor state at `address` (or an error if there is none).
 	Actor(address Address) (Actor, error)
+
+	// Returns an abstraction over a payment channel actors state.
+	PaymentChannelActorState(address Address) (PaymentChannelActorState, error)
+
 	// Returns the actor storage for the actor at `address` (which is empty if there is no such actor).
 	Storage(address Address) (Storage, error)
 
@@ -34,4 +41,13 @@ type Actor interface {
 // Storage provides a key/value store for actor state.
 type Storage interface {
 	Get(c cid.Cid, out interface{}) error
+}
+
+// PaymentChannelActorState is an abstraction over a payment channel actor's state.
+type PaymentChannelActorState interface {
+	From() Address
+	To() Address
+	ToSend() AttoFIL
+	ClosingAt() uint64
+	MinCloseHeight() uint64
 }

--- a/pkg/state/wrapper.go
+++ b/pkg/state/wrapper.go
@@ -33,5 +33,5 @@ type Actor interface {
 
 // Storage provides a key/value store for actor state.
 type Storage interface {
-	Get(cid cid.Cid) ([]byte, error)
+	Get(c cid.Cid, out interface{}) error
 }

--- a/pkg/suites/driver.go
+++ b/pkg/suites/driver.go
@@ -54,8 +54,7 @@ func (d *StateDriver) AssertBalance(addr state.Address, expected uint64) {
 
 // AssertReceipt checks that a receipt is not nill and has values equal to `expected`.
 func (d *StateDriver) AssertReceipt(receipt, expected chain.MessageReceipt) {
-	// TODO uncomment when gas values stabalize
-	//assert.Equal(t, expected.GasUsed, receipt.GasUsed)
+	assert.Equal(d.tb, expected.GasUsed, receipt.GasUsed)
 	assert.NotNil(d.tb, receipt)
 	assert.Equal(d.tb, expected.ReturnValue, receipt.ReturnValue)
 	assert.Equal(d.tb, expected.ExitCode, receipt.ExitCode)

--- a/pkg/suites/paymentchannel_actor.go
+++ b/pkg/suites/paymentchannel_actor.go
@@ -1,6 +1,7 @@
 package suites
 
 import (
+	"github.com/stretchr/testify/assert"
 	"math/big"
 	"testing"
 
@@ -53,17 +54,11 @@ func PaymentChannelCreateSuccess(t *testing.T, factory Factories, expGasUsed uin
 	drv.AssertBalance(miner, expGasUsed)
 	drv.AssertBalance(expPayChAddress, 50)
 
-	// TODO make this state inspection work
-	/*
-		pca, err := drv.State().Actor(expPayChAddress)
-		require.NoError(t, err)
+	pcaState, err := drv.State().PaymentChannelActorState(expPayChAddress)
+	require.NoError(t, err)
 
-		pcaStorage, err := drv.State().Storage(expPayChAddress)
-		require.NoError(t, err)
-
-		var pcs state.PaymentChannelActorState
-		require.NoError(t,pcaStorage.Get(pca.Head(), &pcs))
-		assert.Equal(t, []byte(alice), pcs.From)
-		assert.Equal(t, []byte(bob), pcs.To)
-	*/
+	assert.Equal(t, bob, pcaState.To())
+	assert.Equal(t, alice, pcaState.From())
+	assert.Zero(t, pcaState.MinCloseHeight())
+	assert.Zero(t, pcaState.ClosingAt())
 }

--- a/pkg/suites/paymentchannel_actor.go
+++ b/pkg/suites/paymentchannel_actor.go
@@ -1,0 +1,69 @@
+package suites
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/chain-validation/pkg/chain"
+	"github.com/filecoin-project/chain-validation/pkg/state"
+)
+
+func testSetup(t *testing.T, factory Factories) (*StateDriver, *chain.MessageProducer, *chain.Validator) {
+	drv := NewStateDriver(t, factory.NewState())
+
+	_, _, err := drv.State().SetSingletonActor(state.InitAddress, big.NewInt(0))
+	require.NoError(t, err)
+
+	gasPrice := big.NewInt(1)
+	gasLimit := state.GasUnit(10000)
+
+	producer := chain.NewMessageProducer(factory.NewMessageFactory(drv.State()), gasLimit, gasPrice)
+	validator := chain.NewValidator(factory)
+
+	return drv, producer, validator
+}
+
+func PaymentChannelCreateSuccess(t *testing.T, factory Factories, expGasUsed uint64) {
+	drv, producer, validator := testSetup(t, factory)
+
+	expPayChAddress, err := state.NewIDAddress(103)
+
+	alice := drv.NewAccountActor(30000)
+	bob := drv.NewAccountActor(0)
+	miner := drv.NewAccountActor(0) // Miner owner
+
+	exeCtx := chain.NewExecutionContext(1, miner)
+
+	msg, err := producer.PaymentChannelCreate(bob, alice, 0, 50)
+	require.NoError(t, err)
+
+	msgReceipt, err := validator.ApplyMessage(exeCtx, drv.State(), msg)
+	require.NoError(t, err)
+	drv.AssertReceipt(msgReceipt, chain.MessageReceipt{
+		ExitCode:    0,
+		ReturnValue: []byte(expPayChAddress),
+		GasUsed:     state.GasUnit(expGasUsed),
+	})
+
+	// initial balance - paych amount - gas
+	drv.AssertBalance(alice, 30000-50-expGasUsed)
+	drv.AssertBalance(bob, 0)
+	drv.AssertBalance(miner, expGasUsed)
+	drv.AssertBalance(expPayChAddress, 50)
+
+	// TODO make this state inspection work
+	/*
+		pca, err := drv.State().Actor(expPayChAddress)
+		require.NoError(t, err)
+
+		pcaStorage, err := drv.State().Storage(expPayChAddress)
+		require.NoError(t, err)
+
+		var pcs state.PaymentChannelActorState
+		require.NoError(t,pcaStorage.Get(pca.Head(), &pcs))
+		assert.Equal(t, []byte(alice), pcs.From)
+		assert.Equal(t, []byte(bob), pcs.To)
+	*/
+}

--- a/pkg/suites/storageminertest.go
+++ b/pkg/suites/storageminertest.go
@@ -36,7 +36,6 @@ func CreateStorageMinerAndUpdatePeerIDTest(t testing.TB, factory Factories) {
 	_, _, err = drv.State().SetSingletonActor(state.StoragePowerAddress, big.NewInt(0))
 	require.NoError(t, err)
 
-
 	// miner that mines in this test
 	testMiner := drv.NewAccountActor(0)
 	// account that will own the miner
@@ -49,12 +48,12 @@ func CreateStorageMinerAndUpdatePeerIDTest(t testing.TB, factory Factories) {
 	sectorSize := big.NewInt(int64(sectorSizes[0]))
 	// peerID of the miner created
 	rawPeerID, err := RequireIntPeerID(t, 1).MarshalBinary()
-	require.NoError(t,err)
+	require.NoError(t, err)
 	peerID := state.PeerID(rawPeerID)
 	// peerID of the miner after update
-	rawPeerID2, err := RequireIntPeerID(t,2).MarshalBinary()
-	require.NoError(t,err)
-	peerID2 :=state.PeerID(rawPeerID2)
+	rawPeerID2, err := RequireIntPeerID(t, 2).MarshalBinary()
+	require.NoError(t, err)
+	peerID2 := state.PeerID(rawPeerID2)
 
 	producer := chain.NewMessageProducer(factory.NewMessageFactory(drv.State()), gasLimit, gasPrice)
 	validator := chain.NewValidator(factory)
@@ -86,7 +85,6 @@ func CreateStorageMinerAndUpdatePeerIDTest(t testing.TB, factory Factories) {
 		GasUsed:     0,
 	})
 
-
 	//
 	// verify storage miners owner
 	//
@@ -112,7 +110,6 @@ func CreateStorageMinerAndUpdatePeerIDTest(t testing.TB, factory Factories) {
 		ReturnValue: []byte{},
 		GasUsed:     0,
 	})
-
 
 	//
 	// verify storage miner worker address

--- a/pkg/suites/transfer.go
+++ b/pkg/suites/transfer.go
@@ -46,7 +46,7 @@ func AccountValueTransferSuccess(t *testing.T, factory Factories, expGasUsed uin
 	assert.Empty(t, msgReceipt.ReturnValue)
 	assert.Equal(t, state.GasUnit(expGasUsed), msgReceipt.GasUsed)
 
-	drv.AssertBalance(alice, 1950 - expGasUsed)
+	drv.AssertBalance(alice, 1950-expGasUsed)
 	drv.AssertBalance(bob, 50)
 	// This should become non-zero after gas tracking and payments are integrated.
 	drv.AssertBalance(miner, expGasUsed)
@@ -72,7 +72,7 @@ func AccountValueTransferZeroFunds(t *testing.T, factory Factories, expGasUsed u
 	assert.Empty(t, msgReceipt.ReturnValue)
 	assert.Equal(t, state.GasUnit(expGasUsed), msgReceipt.GasUsed)
 
-	drv.AssertBalance(alice, 2000 - expGasUsed)
+	drv.AssertBalance(alice, 2000-expGasUsed)
 	drv.AssertBalance(bob, 0)
 	// This should become non-zero after gas tracking and payments are integrated.
 	drv.AssertBalance(miner, expGasUsed)
@@ -98,7 +98,7 @@ func AccountValueTransferOverBalanceNonZero(t *testing.T, factory Factories, exp
 	assert.Empty(t, msgReceipt.ReturnValue)
 	assert.Equal(t, state.GasUnit(expGasUsed), msgReceipt.GasUsed)
 
-	drv.AssertBalance(alice, 2000 - expGasUsed)
+	drv.AssertBalance(alice, 2000-expGasUsed)
 	drv.AssertBalance(bob, 0)
 	// This should become non-zero after gas tracking and payments are integrated.
 	drv.AssertBalance(miner, expGasUsed)


### PR DESCRIPTION
### Implementation
This PR is the start of adding payment channel tests, currently it implements a single test called `PaymentChannelCreateSuccess` -- It exercises payment channel creation. To facilitate payment channel actor state inspection a [new interface](https://github.com/filecoin-project/chain-validation/pull/13/files#diff-1de7e0cfa311e395cda7b4256aa34d8eR46-R52) was added to the state wrapper, its usage can be seen [here](https://github.com/filecoin-project/chain-validation/pull/13/files#diff-1bf47d3c34fb5fd576e51a055e2d99b2R57-R64)
