### PR TITLE
refactor: rename candy and types

### DIFF
--- a/pkg/chain/message.go
+++ b/pkg/chain/message.go
@@ -1,6 +1,7 @@
 package chain
 
 import (
+	"github.com/filecoin-project/chain-validation/pkg/state"
 	"github.com/filecoin-project/go-address"
 	"github.com/ipfs/go-cid"
 	"github.com/libp2p/go-libp2p-core/peer"
@@ -221,7 +222,7 @@ func (mp *MessageProducer) Transfer(from, to address.Address, nonce uint64, valu
 // InitExec builds a message invoking InitActor.Exec and returns it.
 func (mp *MessageProducer) InitExec(from address.Address, nonce uint64, code actors.ActorCodeID, params []byte, opts ...MsgOpt) (*Message, error) {
 	iaAddr := mp.actorInfo.FromSingletonAddress(actors.InitAddress)
-	initParams, err := types.Serialize(&initialize.ExecParams{
+	initParams, err := state.Serialize(&initialize.ExecParams{
 		Code:   mp.actorInfo.FromActorCodeCid(code),
 		Params: params,
 	})
@@ -236,7 +237,7 @@ func (mp *MessageProducer) InitExec(from address.Address, nonce uint64, code act
 //
 
 func (mp *MessageProducer) StorageMarketWithdrawBalance(from address.Address, nonce uint64, balance types.BigInt, opts ...MsgOpt) (*Message, error) {
-	params, err := types.Serialize(&strgmrkt.WithdrawBalanceParams{Balance: balance})
+	params, err := state.Serialize(&strgmrkt.WithdrawBalanceParams{Balance: balance})
 	if err != nil {
 		return nil, err
 	}
@@ -250,7 +251,7 @@ func (mp *MessageProducer) StorageMarketAddBalance(from address.Address, nonce u
 }
 
 func (mp *MessageProducer) StorageMarketPublishStorageDeals(from address.Address, nonce uint64, deals []strgmrkt.StorageDeal, opts ...MsgOpt) (*Message, error) {
-	params, err := types.Serialize(&strgmrkt.PublishStorageDealsParams{Deals: deals})
+	params, err := state.Serialize(&strgmrkt.PublishStorageDealsParams{Deals: deals})
 	if err != nil {
 		return nil, err
 	}
@@ -259,7 +260,7 @@ func (mp *MessageProducer) StorageMarketPublishStorageDeals(from address.Address
 }
 
 func (mp *MessageProducer) StorageMarketActivateStorageDeals(from address.Address, nonce uint64, dealIDs []uint64, opts ...MsgOpt) (*Message, error) {
-	params, err := types.Serialize(&strgmrkt.ActivateStorageDealsParams{Deals: dealIDs})
+	params, err := state.Serialize(&strgmrkt.ActivateStorageDealsParams{Deals: dealIDs})
 	if err != nil {
 		return nil, err
 	}
@@ -268,7 +269,7 @@ func (mp *MessageProducer) StorageMarketActivateStorageDeals(from address.Addres
 }
 
 func (mp *MessageProducer) StorageMarketComputeDataCommitment(from address.Address, nonce uint64, sectorSize uint64, dealIDs []uint64, opts ...MsgOpt) (*Message, error) {
-	params, err := types.Serialize(&strgmrkt.ComputeDataCommitmentParams{
+	params, err := state.Serialize(&strgmrkt.ComputeDataCommitmentParams{
 		DealIDs:    dealIDs,
 		SectorSize: sectorSize,
 	})
@@ -289,7 +290,7 @@ func (mp *MessageProducer) StoragePowerCreateStorageMiner(from address.Address, 
 	opts ...MsgOpt) (*Message, error) {
 
 	spaAddr := mp.actorInfo.FromSingletonAddress(actors.StoragePowerAddress)
-	params, err := types.Serialize(&strgpwr.CreateStorageMinerParams{
+	params, err := state.Serialize(&strgpwr.CreateStorageMinerParams{
 		Owner:      owner,
 		Worker:     worker,
 		SectorSize: sectorSize,
@@ -302,7 +303,7 @@ func (mp *MessageProducer) StoragePowerCreateStorageMiner(from address.Address, 
 }
 
 func (mp *MessageProducer) StoragePowerUpdateStorage(from address.Address, nonce uint64, delta types.BigInt, nextppEnd, previousppEnd uint64, opts ...MsgOpt) (*Message, error) {
-	params, err := types.Serialize(&strgpwr.UpdateStorageParams{
+	params, err := state.Serialize(&strgpwr.UpdateStorageParams{
 		Delta:                    delta,
 		NextProvingPeriodEnd:     nextppEnd,
 		PreviousProvingPeriodEnd: previousppEnd,
@@ -315,7 +316,7 @@ func (mp *MessageProducer) StoragePowerUpdateStorage(from address.Address, nonce
 }
 
 func (mp *MessageProducer) StoragePowerPledgeCollateralForSize(from address.Address, nonce uint64, size types.BigInt, opts ...MsgOpt) (*Message, error) {
-	params, err := types.Serialize(&strgpwr.PledgeCollateralParams{Size: size})
+	params, err := state.Serialize(&strgpwr.PledgeCollateralParams{Size: size})
 	if err != nil {
 		return nil, err
 	}
@@ -324,7 +325,7 @@ func (mp *MessageProducer) StoragePowerPledgeCollateralForSize(from address.Addr
 }
 
 func (mp *MessageProducer) StoragePowerLookupPower(from address.Address, nonce uint64, miner address.Address, opts ...MsgOpt) (*Message, error) {
-	params, err := types.Serialize(&strgpwr.PowerLookupParams{Miner: miner})
+	params, err := state.Serialize(&strgpwr.PowerLookupParams{Miner: miner})
 	if err != nil {
 		return nil, err
 	}
@@ -337,7 +338,7 @@ func (mp *MessageProducer) StoragePowerLookupPower(from address.Address, nonce u
 //
 
 func (mp *MessageProducer) StorageMinerUpdatePeerID(to, from address.Address, nonce uint64, peerID peer.ID, opts ...MsgOpt) (*Message, error) {
-	params, err := types.Serialize(&strgminr.UpdatePeerIDParams{PeerID: peerID})
+	params, err := state.Serialize(&strgminr.UpdatePeerIDParams{PeerID: peerID})
 	if err != nil {
 		return nil, err
 	}
@@ -369,7 +370,7 @@ func (mp *MessageProducer) StorageMinerGetSectorSize(to, from address.Address, n
 //
 
 func (mp *MessageProducer) MultiSigPropose(to, from address.Address, nonce uint64, proposeTo address.Address, proposeValue types.BigInt, proposeMethod uint64, proposeParams []byte, opts ...MsgOpt) (*Message, error) {
-	params, err := types.Serialize(&multsig.MultiSigProposeParams{
+	params, err := state.Serialize(&multsig.MultiSigProposeParams{
 		To:     proposeTo,
 		Value:  proposeValue,
 		Method: proposeMethod,
@@ -382,7 +383,7 @@ func (mp *MessageProducer) MultiSigPropose(to, from address.Address, nonce uint6
 }
 
 func (mp *MessageProducer) MultiSigApprove(to, from address.Address, nonce uint64, txID uint64, opts ...MsgOpt) (*Message, error) {
-	params, err := types.Serialize(&multsig.MultiSigTxID{TxID: txID})
+	params, err := state.Serialize(&multsig.MultiSigTxID{TxID: txID})
 	if err != nil {
 		return nil, err
 	}
@@ -390,7 +391,7 @@ func (mp *MessageProducer) MultiSigApprove(to, from address.Address, nonce uint6
 }
 
 func (mp *MessageProducer) MultiSigCancel(to, from address.Address, nonce uint64, txID uint64, opts ...MsgOpt) (*Message, error) {
-	params, err := types.Serialize(&multsig.MultiSigTxID{TxID: txID})
+	params, err := state.Serialize(&multsig.MultiSigTxID{TxID: txID})
 	if err != nil {
 		return nil, err
 	}
@@ -398,7 +399,7 @@ func (mp *MessageProducer) MultiSigCancel(to, from address.Address, nonce uint64
 }
 
 func (mp *MessageProducer) MultiSigAddSigner(to, from address.Address, nonce uint64, signer address.Address, increase bool, opts ...MsgOpt) (*Message, error) {
-	params, err := types.Serialize(&multsig.MultiSigAddSignerParam{
+	params, err := state.Serialize(&multsig.MultiSigAddSignerParam{
 		Signer:   signer,
 		Increase: increase,
 	})
@@ -409,7 +410,7 @@ func (mp *MessageProducer) MultiSigAddSigner(to, from address.Address, nonce uin
 }
 
 func (mp *MessageProducer) MultiSigRemoveSigner(to, from address.Address, nonce uint64, signer address.Address, decrease bool, opts ...MsgOpt) (*Message, error) {
-	params, err := types.Serialize(&multsig.MultiSigRemoveSignerParam{
+	params, err := state.Serialize(&multsig.MultiSigRemoveSignerParam{
 		Signer:   signer,
 		Decrease: decrease,
 	})
@@ -420,7 +421,7 @@ func (mp *MessageProducer) MultiSigRemoveSigner(to, from address.Address, nonce 
 }
 
 func (mp *MessageProducer) MultiSigSwapSigner(to, from address.Address, nonce uint64, swapFrom, swapTo address.Address, opts ...MsgOpt) (*Message, error) {
-	params, err := types.Serialize(&multsig.MultiSigSwapSignerParams{
+	params, err := state.Serialize(&multsig.MultiSigSwapSignerParams{
 		From: swapFrom,
 		To:   swapTo,
 	})
@@ -431,7 +432,7 @@ func (mp *MessageProducer) MultiSigSwapSigner(to, from address.Address, nonce ui
 }
 
 func (mp *MessageProducer) MultiSigChangeRequirement(to, from address.Address, nonce uint64, req uint64, opts ...MsgOpt) (*Message, error) {
-	params, err := types.Serialize(&multsig.MultiSigChangeReqParams{Req: req})
+	params, err := state.Serialize(&multsig.MultiSigChangeReqParams{Req: req})
 	if err != nil {
 		return nil, err
 	}
@@ -443,7 +444,7 @@ func (mp *MessageProducer) MultiSigChangeRequirement(to, from address.Address, n
 //
 
 func (mp *MessageProducer) PaychUpdateChannelState(to, from address.Address, nonce uint64, sv types.SignedVoucher, secret, proof []byte, opts ...MsgOpt) (*Message, error) {
-	params, err := types.Serialize(&paych.PaymentChannelUpdateParams{
+	params, err := state.Serialize(&paych.PaymentChannelUpdateParams{
 		Sv:     sv,
 		Secret: secret,
 		Proof:  proof,

--- a/pkg/state/serialization.go
+++ b/pkg/state/serialization.go
@@ -1,4 +1,4 @@
-package types
+package state
 
 import (
 	"bytes"

--- a/pkg/suites/storagemarket.go
+++ b/pkg/suites/storagemarket.go
@@ -2,6 +2,7 @@ package suites
 
 import (
 	"context"
+	"github.com/filecoin-project/chain-validation/pkg/state"
 	"testing"
 
 	"github.com/filecoin-project/go-address"
@@ -15,13 +16,13 @@ import (
 )
 
 func StorageMarketActorConstructor(t testing.TB, factory Factories) {
-	c := NewCandy(t, factory, map[actors.SingletonActorID]types.BigInt{
+	td := NewTestDriver(t, factory, map[actors.SingletonActorID]types.BigInt{
 		actors.InitAddress:         types.NewInt(0),
 		actors.BurntFundsAddress:   types.NewInt(0),
 		actors.StoragePowerAddress: types.NewInt(0),
 		actors.NetworkAddress:      TotalNetworkBalance,
 	})
-	mustCreateStorageMarketActor(c)
+	mustCreateStorageMarketActor(td)
 }
 
 func StorageMarketBalanceUpdates(t testing.TB, factory Factories) {
@@ -29,25 +30,25 @@ func StorageMarketBalanceUpdates(t testing.TB, factory Factories) {
 	const balAddAmount = 100
 	const balWithdrawAmount = 10
 
-	c := NewCandy(t, factory, map[actors.SingletonActorID]types.BigInt{
+	td := NewTestDriver(t, factory, map[actors.SingletonActorID]types.BigInt{
 		actors.InitAddress:         types.NewInt(0),
 		actors.BurntFundsAddress:   types.NewInt(0),
 		actors.StoragePowerAddress: types.NewInt(0),
 		actors.NetworkAddress:      TotalNetworkBalance,
 	})
-	smaddr := mustCreateStorageMarketActor(c)
+	smaddr := mustCreateStorageMarketActor(td)
 
-	alice := c.Driver().NewAccountActor(initialBal)
-	bob := c.Driver().NewAccountActor(initialBal)
+	alice := td.Driver().NewAccountActor(initialBal)
+	bob := td.Driver().NewAccountActor(initialBal)
 
-	mustAddBalance(c, alice, 0, balAddAmount)
-	c.Driver().AssertStorageMarketParticipantAvailableBalance(smaddr, alice, types.NewInt(balAddAmount))
+	mustAddBalance(td, alice, 0, balAddAmount)
+	td.Driver().AssertStorageMarketParticipantAvailableBalance(smaddr, alice, types.NewInt(balAddAmount))
 
-	mustAddBalance(c, bob, 0, balAddAmount)
-	c.Driver().AssertStorageMarketParticipantAvailableBalance(smaddr, bob, types.NewInt(balAddAmount))
+	mustAddBalance(td, bob, 0, balAddAmount)
+	td.Driver().AssertStorageMarketParticipantAvailableBalance(smaddr, bob, types.NewInt(balAddAmount))
 
-	mustWithdrawBalance(c, bob, 1, balWithdrawAmount)
-	c.Driver().AssertStorageMarketParticipantAvailableBalance(smaddr, bob, types.NewInt(balAddAmount-balWithdrawAmount))
+	mustWithdrawBalance(td, bob, 1, balWithdrawAmount)
+	td.Driver().AssertStorageMarketParticipantAvailableBalance(smaddr, bob, types.NewInt(balAddAmount-balWithdrawAmount))
 }
 
 func StorageMarketStoragePublishDeal(t testing.TB, factory Factories) {
@@ -60,7 +61,7 @@ func StorageMarketStoragePublishDeal(t testing.TB, factory Factories) {
 	const collateral = 5
 	ctx := context.Background()
 
-	c := NewCandy(t, factory, map[actors.SingletonActorID]types.BigInt{
+	td := NewTestDriver(t, factory, map[actors.SingletonActorID]types.BigInt{
 		actors.InitAddress:         types.NewInt(0),
 		actors.BurntFundsAddress:   types.NewInt(0),
 		actors.StoragePowerAddress: types.NewInt(0),
@@ -68,25 +69,25 @@ func StorageMarketStoragePublishDeal(t testing.TB, factory Factories) {
 	})
 
 	// create the storage market actor
-	smaddr := mustCreateStorageMarketActor(c)
+	smaddr := mustCreateStorageMarketActor(td)
 
 	// create an account to own a miner.
-	minerOwner := c.Driver().NewAccountActorBigBalance(types.NewIntFromString(initialBal))
+	minerOwner := td.Driver().NewAccountActorBigBalance(types.NewIntFromString(initialBal))
 
-	mustAddBalance(c, minerOwner, 0, dealCost)
-	c.Driver().AssertStorageMarketParticipantAvailableBalance(smaddr, minerOwner, types.NewInt(dealCost))
-	c.Driver().AssertStorageMarketParticipantLockedBalance(smaddr, minerOwner, types.NewInt(0))
+	mustAddBalance(td, minerOwner, 0, dealCost)
+	td.Driver().AssertStorageMarketParticipantAvailableBalance(smaddr, minerOwner, types.NewInt(dealCost))
+	td.Driver().AssertStorageMarketParticipantLockedBalance(smaddr, minerOwner, types.NewInt(0))
 
 	peerID0 := RequireIntPeerID(t, 0)
 	minerAddr, err := address.NewIDAddress(102)
 	require.NoError(t, err)
-	mustCreateStorageMiner(c, 1, strgpwr.SectorSizes[0], types.NewIntFromString("1999999995415053581179420"), minerAddr, minerOwner, minerOwner, minerOwner, peerID0)
+	mustCreateStorageMiner(td, 1, strgpwr.SectorSizes[0], types.NewIntFromString("1999999995415053581179420"), minerAddr, minerOwner, minerOwner, minerOwner, peerID0)
 
 	// create a client and sign the deal
-	client := c.Driver().NewAccountActorBigBalance(types.NewIntFromString(initialBal))
-	mustAddBalance(c, client, 0, dealCost)
-	c.Driver().AssertStorageMarketParticipantAvailableBalance(smaddr, client, types.NewInt(dealCost))
-	c.Driver().AssertStorageMarketParticipantLockedBalance(smaddr, client, types.NewInt(0))
+	client := td.Driver().NewAccountActorBigBalance(types.NewIntFromString(initialBal))
+	mustAddBalance(td, client, 0, dealCost)
+	td.Driver().AssertStorageMarketParticipantAvailableBalance(smaddr, client, types.NewInt(dealCost))
+	td.Driver().AssertStorageMarketParticipantLockedBalance(smaddr, client, types.NewInt(0))
 
 	dealProposal := strgmrkt.StorageDealProposal{
 		PieceRef:             []byte{1},
@@ -99,43 +100,43 @@ func StorageMarketStoragePublishDeal(t testing.TB, factory Factories) {
 		StoragePricePerEpoch: types.NewInt(pricePerEpoch),
 		StorageCollateral:    types.NewInt(collateral),
 	}
-	err = dealProposal.Sign(ctx, client, c.Driver().State())
+	err = dealProposal.Sign(ctx, client, td.Driver().State())
 	require.NoError(t, err)
 
 	// miner signs the deal
 	storageDeal := strgmrkt.StorageDeal{
 		Proposal: dealProposal,
 	}
-	err = storageDeal.Sign(ctx, minerOwner, c.Driver().State())
+	err = storageDeal.Sign(ctx, minerOwner, td.Driver().State())
 	require.NoError(t, err)
 
-	mustPublishStorageDeal(c, 1, client, dealID, storageDeal)
+	mustPublishStorageDeal(td, 1, client, dealID, storageDeal)
 
-	c.Driver().AssertStorageMarketHasOnChainDeal(smaddr, dealID, strgmrkt.OnChainDeal{
+	td.Driver().AssertStorageMarketHasOnChainDeal(smaddr, dealID, strgmrkt.OnChainDeal{
 		Deal:            storageDeal,
 		ActivationEpoch: 0,
 	})
-	c.Driver().AssertStorageMarketParticipantAvailableBalance(smaddr, client, types.NewInt(dealCost-dealProposal.TotalStoragePrice().Uint64()))
-	c.Driver().AssertStorageMarketParticipantAvailableBalance(smaddr, minerOwner, types.NewInt(dealCost-collateral))
+	td.Driver().AssertStorageMarketParticipantAvailableBalance(smaddr, client, types.NewInt(dealCost-dealProposal.TotalStoragePrice().Uint64()))
+	td.Driver().AssertStorageMarketParticipantAvailableBalance(smaddr, minerOwner, types.NewInt(dealCost-collateral))
 
-	c.Driver().AssertStorageMarketParticipantLockedBalance(smaddr, client, types.NewInt(dealCost))
-	c.Driver().AssertStorageMarketParticipantLockedBalance(smaddr, minerOwner, types.NewInt(collateral))
+	td.Driver().AssertStorageMarketParticipantLockedBalance(smaddr, client, types.NewInt(dealCost))
+	td.Driver().AssertStorageMarketParticipantLockedBalance(smaddr, minerOwner, types.NewInt(collateral))
 }
 
-func mustPublishStorageDeal(c Candy, nonce uint64, from address.Address, dealID uint64, storageDeal strgmrkt.StorageDeal) {
+func mustPublishStorageDeal(td TestDriver, nonce uint64, from address.Address, dealID uint64, storageDeal strgmrkt.StorageDeal) {
 	// expected response
 	pubDealResp := strgmrkt.PublishStorageDealResponse{
 		DealIDs: []uint64{dealID},
 	}
-	respBytes, err := types.Serialize(&pubDealResp)
-	require.NoError(c.TB(), err)
+	respBytes, err := state.Serialize(&pubDealResp)
+	require.NoError(td.TB(), err)
 
-	msg, err := c.Producer().StorageMarketPublishStorageDeals(from, nonce, []strgmrkt.StorageDeal{storageDeal}, chain.Value(0))
-	require.NoError(c.TB(), err)
+	msg, err := td.Producer().StorageMarketPublishStorageDeals(from, nonce, []strgmrkt.StorageDeal{storageDeal}, chain.Value(0))
+	require.NoError(td.TB(), err)
 
-	msgReceipt, err := c.Validator().ApplyMessage(c.ExeCtx(), c.Driver().State(), msg)
-	require.NoError(c.TB(), err)
-	c.Driver().AssertReceipt(msgReceipt, chain.MessageReceipt{
+	msgReceipt, err := td.Validator().ApplyMessage(td.ExeCtx(), td.Driver().State(), msg)
+	require.NoError(td.TB(), err)
+	td.Driver().AssertReceipt(msgReceipt, chain.MessageReceipt{
 		ExitCode:    0,
 		ReturnValue: respBytes,
 		GasUsed:     types.NewInt(0),
@@ -143,41 +144,41 @@ func mustPublishStorageDeal(c Candy, nonce uint64, from address.Address, dealID 
 
 }
 
-func mustWithdrawBalance(c Candy, from address.Address, nonce, amount uint64) {
-	msg, err := c.Producer().StorageMarketWithdrawBalance(from, nonce, types.NewInt(amount), chain.Value(0))
-	require.NoError(c.TB(), err)
+func mustWithdrawBalance(td TestDriver, from address.Address, nonce, amount uint64) {
+	msg, err := td.Producer().StorageMarketWithdrawBalance(from, nonce, types.NewInt(amount), chain.Value(0))
+	require.NoError(td.TB(), err)
 
-	msgReceipt, err := c.Validator().ApplyMessage(c.ExeCtx(), c.Driver().State(), msg)
-	require.NoError(c.TB(), err)
+	msgReceipt, err := td.Validator().ApplyMessage(td.ExeCtx(), td.Driver().State(), msg)
+	require.NoError(td.TB(), err)
 
-	c.Driver().AssertReceipt(msgReceipt, chain.MessageReceipt{
+	td.Driver().AssertReceipt(msgReceipt, chain.MessageReceipt{
 		ExitCode:    0,
 		ReturnValue: nil,
 		GasUsed:     types.NewInt(0),
 	})
 }
 
-func mustAddBalance(c Candy, from address.Address, nonce, amount uint64) {
-	msg, err := c.Producer().StorageMarketAddBalance(from, nonce, chain.Value(amount))
-	require.NoError(c.TB(), err)
+func mustAddBalance(td TestDriver, from address.Address, nonce, amount uint64) {
+	msg, err := td.Producer().StorageMarketAddBalance(from, nonce, chain.Value(amount))
+	require.NoError(td.TB(), err)
 
-	msgReceipt, err := c.Validator().ApplyMessage(c.ExeCtx(), c.Driver().State(), msg)
-	require.NoError(c.TB(), err)
+	msgReceipt, err := td.Validator().ApplyMessage(td.ExeCtx(), td.Driver().State(), msg)
+	require.NoError(td.TB(), err)
 
-	c.Driver().AssertReceipt(msgReceipt, chain.MessageReceipt{
+	td.Driver().AssertReceipt(msgReceipt, chain.MessageReceipt{
 		ExitCode:    0,
 		ReturnValue: nil,
 		GasUsed:     types.NewInt(0),
 	})
 }
 
-func mustCreateStorageMarketActor(c Candy) address.Address {
-	_, _, err := c.Driver().State().SetSingletonActor(actors.StorageMarketAddress, types.NewInt(0))
-	require.NoError(c.TB(), err)
+func mustCreateStorageMarketActor(td TestDriver) address.Address {
+	_, _, err := td.Driver().State().SetSingletonActor(actors.StorageMarketAddress, types.NewInt(0))
+	require.NoError(td.TB(), err)
 
-	mt := strgmrkt.NewMarketTracker(c.TB())
-	smaddr := c.Producer().SingletonAddress(actors.StorageMarketAddress)
-	c.Driver().AssertStorageMarketState(smaddr, strgmrkt.StorageMarketState{
+	mt := strgmrkt.NewMarketTracker(td.TB())
+	smaddr := td.Producer().SingletonAddress(actors.StorageMarketAddress)
+	td.Driver().AssertStorageMarketState(smaddr, strgmrkt.StorageMarketState{
 		Balances:   mt.Balance,
 		Deals:      mt.Deals,
 		NextDealID: 0,

--- a/pkg/suites/testdriver.go
+++ b/pkg/suites/testdriver.go
@@ -10,8 +10,7 @@ import (
 	"github.com/filecoin-project/chain-validation/pkg/state/types"
 )
 
-// I kinda hate this name
-type Candy interface {
+type TestDriver interface {
 	TB() testing.TB
 	Driver() *StateDriver
 	Producer() *chain.MessageProducer
@@ -19,7 +18,7 @@ type Candy interface {
 	ExeCtx() *chain.ExecutionContext
 }
 
-func NewCandy(t testing.TB, factory Factories, singletons map[actors.SingletonActorID]types.BigInt) Candy {
+func NewTestDriver(t testing.TB, factory Factories, singletons map[actors.SingletonActorID]types.BigInt) TestDriver {
 	drv := NewStateDriver(t, factory.NewState())
 
 	// TODO make these function opts
@@ -36,7 +35,7 @@ func NewCandy(t testing.TB, factory Factories, singletons map[actors.SingletonAc
 	producer := chain.NewMessageProducer(factory.NewMessageFactory(), factory.NewActorInfoMapping(), gasLimit, gasPrice)
 	validator := chain.NewValidator(factory)
 
-	return &candy{
+	return &testDriver{
 		t:         t,
 		driver:    drv,
 		producer:  producer,
@@ -45,7 +44,7 @@ func NewCandy(t testing.TB, factory Factories, singletons map[actors.SingletonAc
 	}
 }
 
-type candy struct {
+type testDriver struct {
 	t         testing.TB
 	driver    *StateDriver
 	producer  *chain.MessageProducer
@@ -53,22 +52,22 @@ type candy struct {
 	exeCtx    *chain.ExecutionContext
 }
 
-func (c candy) TB() testing.TB {
+func (c testDriver) TB() testing.TB {
 	return c.t
 }
 
-func (c candy) Driver() *StateDriver {
+func (c testDriver) Driver() *StateDriver {
 	return c.driver
 }
 
-func (c candy) Producer() *chain.MessageProducer {
+func (c testDriver) Producer() *chain.MessageProducer {
 	return c.producer
 }
 
-func (c candy) Validator() *chain.Validator {
+func (c testDriver) Validator() *chain.Validator {
 	return c.validator
 }
 
-func (c candy) ExeCtx() *chain.ExecutionContext {
+func (c testDriver) ExeCtx() *chain.ExecutionContext {
 	return c.exeCtx
 }

--- a/pkg/suites/transfer.go
+++ b/pkg/suites/transfer.go
@@ -13,204 +13,204 @@ import (
 func AccountValueTransferSuccess(t *testing.T, factory Factories, expGasUsed uint64) {
 	const initialBal = 20000000000
 	const transferValue = 50
-	c := NewCandy(t, factory, map[actors.SingletonActorID]types.BigInt{
+	td := NewTestDriver(t, factory, map[actors.SingletonActorID]types.BigInt{
 		actors.InitAddress: types.NewInt(0),
 	})
 
-	alice := c.Driver().NewAccountActor(initialBal)
-	bob := c.Driver().NewAccountActor(0)
+	alice := td.Driver().NewAccountActor(initialBal)
+	bob := td.Driver().NewAccountActor(0)
 
-	msg, err := c.Producer().Transfer(alice, bob, 0, transferValue)
+	msg, err := td.Producer().Transfer(alice, bob, 0, transferValue)
 	require.NoError(t, err)
 
-	msgReceipt, err := c.Validator().ApplyMessage(c.ExeCtx(), c.Driver().State(), msg)
+	msgReceipt, err := td.Validator().ApplyMessage(td.ExeCtx(), td.Driver().State(), msg)
 	require.NoError(t, err)
-	c.Driver().AssertReceipt(msgReceipt, chain.MessageReceipt{
+	td.Driver().AssertReceipt(msgReceipt, chain.MessageReceipt{
 		ExitCode:    0,
 		ReturnValue: nil,
 		GasUsed:     types.NewInt(0),
 	})
 
-	c.Driver().AssertBalance(alice, initialBal-transferValue-expGasUsed)
-	c.Driver().AssertBalance(bob, transferValue)
+	td.Driver().AssertBalance(alice, initialBal-transferValue-expGasUsed)
+	td.Driver().AssertBalance(bob, transferValue)
 	// This should become non-zero after gas tracking and payments are integrated.
-	c.Driver().AssertBalance(c.ExeCtx().MinerOwner, expGasUsed)
+	td.Driver().AssertBalance(td.ExeCtx().MinerOwner, expGasUsed)
 }
 
 func AccountValueTransferZeroFunds(t *testing.T, factory Factories, expGasUsed uint64) {
 	const initialBal = 20000000000
 	const transferValue = 0
-	c := NewCandy(t, factory, map[actors.SingletonActorID]types.BigInt{
+	td := NewTestDriver(t, factory, map[actors.SingletonActorID]types.BigInt{
 		actors.InitAddress: types.NewInt(0),
 	})
 
-	alice := c.Driver().NewAccountActor(initialBal)
-	bob := c.Driver().NewAccountActor(0)
+	alice := td.Driver().NewAccountActor(initialBal)
+	bob := td.Driver().NewAccountActor(0)
 
-	msg, err := c.Producer().Transfer(alice, bob, 0, transferValue)
+	msg, err := td.Producer().Transfer(alice, bob, 0, transferValue)
 	require.NoError(t, err)
 
-	msgReceipt, err := c.Validator().ApplyMessage(c.ExeCtx(), c.Driver().State(), msg)
+	msgReceipt, err := td.Validator().ApplyMessage(td.ExeCtx(), td.Driver().State(), msg)
 	require.NoError(t, err)
-	c.Driver().AssertReceipt(msgReceipt, chain.MessageReceipt{
+	td.Driver().AssertReceipt(msgReceipt, chain.MessageReceipt{
 		ExitCode:    0,
 		ReturnValue: nil,
 		GasUsed:     types.NewInt(0),
 	})
 
-	c.Driver().AssertBalance(alice, initialBal-transferValue-expGasUsed)
-	c.Driver().AssertBalance(bob, transferValue)
+	td.Driver().AssertBalance(alice, initialBal-transferValue-expGasUsed)
+	td.Driver().AssertBalance(bob, transferValue)
 	// This should become non-zero after gas tracking and payments are integrated.
-	c.Driver().AssertBalance(c.ExeCtx().MinerOwner, expGasUsed)
+	td.Driver().AssertBalance(td.ExeCtx().MinerOwner, expGasUsed)
 }
 
 func AccountValueTransferOverBalanceNonZero(t *testing.T, factory Factories, expGasUsed uint64) {
-	c := NewCandy(t, factory, map[actors.SingletonActorID]types.BigInt{
+	td := NewTestDriver(t, factory, map[actors.SingletonActorID]types.BigInt{
 		actors.InitAddress: types.NewInt(0),
 	})
 
-	alice := c.Driver().NewAccountActor(2000)
-	bob := c.Driver().NewAccountActor(0)
+	alice := td.Driver().NewAccountActor(2000)
+	bob := td.Driver().NewAccountActor(0)
 
-	msg, err := c.Producer().Transfer(alice, bob, 0, 2001)
+	msg, err := td.Producer().Transfer(alice, bob, 0, 2001)
 	require.NoError(t, err)
 
-	msgReceipt, err := c.Validator().ApplyMessage(c.ExeCtx(), c.Driver().State(), msg)
+	msgReceipt, err := td.Validator().ApplyMessage(td.ExeCtx(), td.Driver().State(), msg)
 	require.Error(t, err)
-	c.Driver().AssertReceipt(msgReceipt, chain.MessageReceipt{
+	td.Driver().AssertReceipt(msgReceipt, chain.MessageReceipt{
 		ExitCode:    0,
 		ReturnValue: nil,
 		GasUsed:     types.NewInt(expGasUsed),
 	})
 
-	c.Driver().AssertBalance(alice, 2000-expGasUsed)
-	c.Driver().AssertBalance(bob, 0)
+	td.Driver().AssertBalance(alice, 2000-expGasUsed)
+	td.Driver().AssertBalance(bob, 0)
 	// This should become non-zero after gas tracking and payments are integrated.
-	c.Driver().AssertBalance(c.ExeCtx().MinerOwner, expGasUsed)
+	td.Driver().AssertBalance(td.ExeCtx().MinerOwner, expGasUsed)
 }
 
 func AccountValueTransferOverBalanceZero(t *testing.T, factory Factories, expGasUsed uint64) {
-	c := NewCandy(t, factory, map[actors.SingletonActorID]types.BigInt{
+	td := NewTestDriver(t, factory, map[actors.SingletonActorID]types.BigInt{
 		actors.InitAddress: types.NewInt(0),
 	})
 
-	alice := c.Driver().NewAccountActor(0)
-	bob := c.Driver().NewAccountActor(0)
+	alice := td.Driver().NewAccountActor(0)
+	bob := td.Driver().NewAccountActor(0)
 
-	msg, err := c.Producer().Transfer(alice, bob, 0, 1)
+	msg, err := td.Producer().Transfer(alice, bob, 0, 1)
 	require.NoError(t, err)
 
-	msgReceipt, err := c.Validator().ApplyMessage(c.ExeCtx(), c.Driver().State(), msg)
+	msgReceipt, err := td.Validator().ApplyMessage(td.ExeCtx(), td.Driver().State(), msg)
 	require.Error(t, err)
-	c.Driver().AssertReceipt(msgReceipt, chain.MessageReceipt{
+	td.Driver().AssertReceipt(msgReceipt, chain.MessageReceipt{
 		ExitCode:    0,
 		ReturnValue: nil,
 		GasUsed:     types.NewInt(expGasUsed),
 	})
 
-	c.Driver().AssertBalance(alice, 0)
-	c.Driver().AssertBalance(bob, 0)
+	td.Driver().AssertBalance(alice, 0)
+	td.Driver().AssertBalance(bob, 0)
 	// This should become non-zero after gas tracking and payments are integrated.
-	c.Driver().AssertBalance(c.ExeCtx().MinerOwner, expGasUsed)
+	td.Driver().AssertBalance(td.ExeCtx().MinerOwner, expGasUsed)
 }
 
 func AccountValueTransferToSelf(t *testing.T, factory Factories, expGasUsed uint64) {
-	c := NewCandy(t, factory, map[actors.SingletonActorID]types.BigInt{
+	td := NewTestDriver(t, factory, map[actors.SingletonActorID]types.BigInt{
 		actors.InitAddress: types.NewInt(0),
 	})
 
-	alice := c.Driver().NewAccountActor(1)
+	alice := td.Driver().NewAccountActor(1)
 
-	msg, err := c.Producer().Transfer(alice, alice, 0, 1)
+	msg, err := td.Producer().Transfer(alice, alice, 0, 1)
 	require.NoError(t, err)
 
-	msgReceipt, err := c.Validator().ApplyMessage(c.ExeCtx(), c.Driver().State(), msg)
+	msgReceipt, err := td.Validator().ApplyMessage(td.ExeCtx(), td.Driver().State(), msg)
 	require.Error(t, err)
-	c.Driver().AssertReceipt(msgReceipt, chain.MessageReceipt{
+	td.Driver().AssertReceipt(msgReceipt, chain.MessageReceipt{
 		ExitCode:    0,
 		ReturnValue: nil,
 		GasUsed:     types.NewInt(expGasUsed),
 	})
 
-	c.Driver().AssertBalance(alice, 1)
+	td.Driver().AssertBalance(alice, 1)
 	// This should become non-zero after gas tracking and payments are integrated.
-	c.Driver().AssertBalance(c.ExeCtx().MinerOwner, expGasUsed)
+	td.Driver().AssertBalance(td.ExeCtx().MinerOwner, expGasUsed)
 }
 
 func AccountValueTransferFromKnownToUnknownAccount(t *testing.T, factory Factories, expGasUsed uint64) {
-	c := NewCandy(t, factory, map[actors.SingletonActorID]types.BigInt{
+	td := NewTestDriver(t, factory, map[actors.SingletonActorID]types.BigInt{
 		actors.InitAddress: types.NewInt(0),
 	})
 
-	alice := c.Driver().NewAccountActor(1)
-	unknown, err := c.Driver().State().NewAccountAddress()
+	alice := td.Driver().NewAccountActor(1)
+	unknown, err := td.Driver().State().NewAccountAddress()
 	require.NoError(t, err)
 
-	msg, err := c.Producer().Transfer(alice, unknown, 0, 1)
+	msg, err := td.Producer().Transfer(alice, unknown, 0, 1)
 	require.NoError(t, err)
 
-	msgReceipt, err := c.Validator().ApplyMessage(c.ExeCtx(), c.Driver().State(), msg)
+	msgReceipt, err := td.Validator().ApplyMessage(td.ExeCtx(), td.Driver().State(), msg)
 	require.Error(t, err)
-	c.Driver().AssertReceipt(msgReceipt, chain.MessageReceipt{
+	td.Driver().AssertReceipt(msgReceipt, chain.MessageReceipt{
 		ExitCode:    0,
 		ReturnValue: nil,
 		GasUsed:     types.NewInt(expGasUsed),
 	})
 
-	c.Driver().AssertBalance(alice, 1)
+	td.Driver().AssertBalance(alice, 1)
 	// This should become non-zero after gas tracking and payments are integrated.
-	c.Driver().AssertBalance(c.ExeCtx().MinerOwner, expGasUsed)
+	td.Driver().AssertBalance(td.ExeCtx().MinerOwner, expGasUsed)
 }
 
 func AccountValueTransferFromUnknownToKnownAccount(t *testing.T, factory Factories, expGasUsed uint64) {
-	c := NewCandy(t, factory, map[actors.SingletonActorID]types.BigInt{
+	td := NewTestDriver(t, factory, map[actors.SingletonActorID]types.BigInt{
 		actors.InitAddress: types.NewInt(0),
 	})
 
-	alice := c.Driver().NewAccountActor(1)
-	unknown, err := c.Driver().State().NewAccountAddress()
+	alice := td.Driver().NewAccountActor(1)
+	unknown, err := td.Driver().State().NewAccountAddress()
 	require.NoError(t, err)
 
-	msg, err := c.Producer().Transfer(unknown, alice, 0, 1)
+	msg, err := td.Producer().Transfer(unknown, alice, 0, 1)
 	require.NoError(t, err)
 
-	msgReceipt, err := c.Validator().ApplyMessage(c.ExeCtx(), c.Driver().State(), msg)
+	msgReceipt, err := td.Validator().ApplyMessage(td.ExeCtx(), td.Driver().State(), msg)
 	require.Error(t, err)
-	c.Driver().AssertReceipt(msgReceipt, chain.MessageReceipt{
+	td.Driver().AssertReceipt(msgReceipt, chain.MessageReceipt{
 		ExitCode:    0,
 		ReturnValue: nil,
 		GasUsed:     types.NewInt(expGasUsed),
 	})
 
-	c.Driver().AssertBalance(alice, 1)
+	td.Driver().AssertBalance(alice, 1)
 	// This should become non-zero after gas tracking and payments are integrated.
-	c.Driver().AssertBalance(c.ExeCtx().MinerOwner, expGasUsed)
+	td.Driver().AssertBalance(td.ExeCtx().MinerOwner, expGasUsed)
 }
 
 func AccountValueTransferFromUnknownToUnknownAccount(t *testing.T, factory Factories, expGasUsed uint64) {
-	c := NewCandy(t, factory, map[actors.SingletonActorID]types.BigInt{
+	td := NewTestDriver(t, factory, map[actors.SingletonActorID]types.BigInt{
 		actors.InitAddress: types.NewInt(0),
 	})
 
-	alice := c.Driver().NewAccountActor(1)
-	unknown, err := c.Driver().State().NewAccountAddress()
+	alice := td.Driver().NewAccountActor(1)
+	unknown, err := td.Driver().State().NewAccountAddress()
 	require.NoError(t, err)
 
-	nobody, err := c.Driver().State().NewAccountAddress()
+	nobody, err := td.Driver().State().NewAccountAddress()
 	require.NoError(t, err)
 
-	msg, err := c.Producer().Transfer(unknown, nobody, 0, 1)
+	msg, err := td.Producer().Transfer(unknown, nobody, 0, 1)
 	require.NoError(t, err)
 
-	msgReceipt, err := c.Validator().ApplyMessage(c.ExeCtx(), c.Driver().State(), msg)
+	msgReceipt, err := td.Validator().ApplyMessage(td.ExeCtx(), td.Driver().State(), msg)
 	require.Error(t, err)
-	c.Driver().AssertReceipt(msgReceipt, chain.MessageReceipt{
+	td.Driver().AssertReceipt(msgReceipt, chain.MessageReceipt{
 		ExitCode:    0,
 		ReturnValue: nil,
 		GasUsed:     types.NewInt(expGasUsed),
 	})
 
-	c.Driver().AssertBalance(alice, 1)
+	td.Driver().AssertBalance(alice, 1)
 	// This should become non-zero after gas tracking and payments are integrated.
-	c.Driver().AssertBalance(c.ExeCtx().MinerOwner, expGasUsed)
+	td.Driver().AssertBalance(td.ExeCtx().MinerOwner, expGasUsed)
 }


### PR DESCRIPTION
move serialization code out of types pkg
rename candy interface to something better -- TestDriver.