### PR TITLE
refactor: clean up message building an errors

### DIFF
--- a/pkg/suites/multisig.go
+++ b/pkg/suites/multisig.go
@@ -76,7 +76,7 @@ func MultiSigActorProposeApprove(t testing.TB, factory Factories) {
 
 	// setup propose expected values and params
 	txID0 := multisig_spec.TxnID(0)
-	pparams := &multisig_spec.ProposeParams{
+	pparams := multisig_spec.ProposeParams{
 		To:     outsider,
 		Value:  valueSend,
 		Method: builtin_spec.MethodSend,
@@ -96,12 +96,12 @@ func MultiSigActorProposeApprove(t testing.TB, factory Factories) {
 	// outsider proposes themselves to receive 'valueSend' FIL. This fails as they are not a signer.
 	td.ApplyMessageExpectReceipt(
 		func() (*chain.Message, error) {
-			return td.Producer.MultiSigPropose(multisigAddr, outsider, 0, &multisig_spec.ProposeParams{
+			return td.Producer.MultiSigPropose(multisigAddr, outsider, multisig_spec.ProposeParams{
 				To:     outsider,
 				Value:  valueSend,
 				Method: builtin_spec.MethodSend,
 				Params: []byte{},
-			}, chain.Value(big_spec.Zero()))
+			}, chain.Value(big_spec.Zero()), chain.Nonce(0))
 		},
 		chain.MessageReceipt{
 			ExitCode:    exitcode_spec.ErrForbidden,
@@ -113,7 +113,7 @@ func MultiSigActorProposeApprove(t testing.TB, factory Factories) {
 	// outsider approves the value transfer alice sent. This fails as they are not a signer.
 	td.ApplyMessageExpectReceipt(
 		func() (*chain.Message, error) {
-			return td.Producer.MultiSigApprove(multisigAddr, outsider, 1, txID0, chain.Value(big_spec.Zero()))
+			return td.Producer.MultiSigApprove(multisigAddr, outsider, txID0, chain.Value(big_spec.Zero()), chain.Nonce(1))
 		},
 		chain.MessageReceipt{
 			ExitCode:    exitcode_spec.ErrForbidden,
@@ -166,7 +166,7 @@ func MultiSigActorProposeCancel(t testing.TB, factory Factories) {
 
 	// alice proposes that outsider should receive 'valueSend' FIL.
 	txID0 := multisig_spec.TxnID(0)
-	pparams := &multisig_spec.ProposeParams{
+	pparams := multisig_spec.ProposeParams{
 		To:     outsider,
 		Value:  valueSend,
 		Method: builtin_spec.MethodSend,
@@ -186,7 +186,7 @@ func MultiSigActorProposeCancel(t testing.TB, factory Factories) {
 	// bob cancels alice's transaction. This fails as bob did not create alice's transaction.
 	td.ApplyMessageExpectReceipt(
 		func() (*chain.Message, error) {
-			return td.Producer.MultiSigCancel(multisigAddr, bob, 0, txID0, chain.Value(big_spec.Zero()))
+			return td.Producer.MultiSigCancel(multisigAddr, bob, txID0, chain.Value(big_spec.Zero()), chain.Nonce(0))
 		},
 		chain.MessageReceipt{
 			ExitCode:    exitcode_spec.ErrForbidden,

--- a/pkg/suites/testdriver.go
+++ b/pkg/suites/testdriver.go
@@ -103,7 +103,7 @@ func (td *TestDriver) MustCreateAndVerifyMultisigActor(nonce int64, value abi_sp
 	multiSigConstuctParams, err := state.Serialize(params)
 	require.NoError(td.T, err)
 
-	msg, err := td.Producer.InitExec(from, nonce, builtin_spec.MultisigActorCodeID, multiSigConstuctParams, chain.Value(value))
+	msg, err := td.Producer.InitExec(from, builtin_spec.MultisigActorCodeID, multiSigConstuctParams, chain.Value(value), chain.Nonce(nonce))
 	require.NoError(td.T, err)
 
 	msgReceipt, err := td.Validator.ApplyMessage(td.ExeCtx, td.Driver.State(), msg)
@@ -133,9 +133,9 @@ func (td *TestDriver) MustCreateAndVerifyMultisigActor(nonce int64, value abi_sp
 	td.Driver.AssertBalance(multisigAddr, value)
 }
 
-func (td *TestDriver) MustProposeMultisigTransfer(nonce int64, value abi_spec.TokenAmount, txID multisig_spec.TxnID, multisigAddr, from address.Address, params *multisig_spec.ProposeParams) {
+func (td *TestDriver) MustProposeMultisigTransfer(nonce int64, value abi_spec.TokenAmount, txID multisig_spec.TxnID, multisigAddr, from address.Address, params multisig_spec.ProposeParams) {
 	/* Propose the transactions */
-	msg, err := td.Producer.MultiSigPropose(multisigAddr, from, nonce, params, chain.Value(value))
+	msg, err := td.Producer.MultiSigPropose(multisigAddr, from, params, chain.Value(value), chain.Nonce(nonce))
 	require.NoError(td.T, err)
 	msgReceipt, err := td.Validator.ApplyMessage(td.ExeCtx, td.Driver.State(), msg)
 	require.NoError(td.T, err)
@@ -152,7 +152,7 @@ func (td *TestDriver) MustProposeMultisigTransfer(nonce int64, value abi_spec.To
 }
 
 func (td *TestDriver) MustApproveMultisigActor(nonce int64, value abi_spec.TokenAmount, ms, from address.Address, txID multisig_spec.TxnID) {
-	msg, err := td.Producer.MultiSigApprove(ms, from, nonce, txID, chain.Value(value))
+	msg, err := td.Producer.MultiSigApprove(ms, from, txID, chain.Value(value), chain.Nonce(nonce))
 	require.NoError(td.T, err)
 
 	msgReceipt, err := td.Validator.ApplyMessage(td.ExeCtx, td.Driver.State(), msg)
@@ -166,7 +166,7 @@ func (td *TestDriver) MustApproveMultisigActor(nonce int64, value abi_spec.Token
 }
 
 func (td *TestDriver) MustCancelMultisigActor(nonce int64, value abi_spec.TokenAmount, ms, from address.Address, txID multisig_spec.TxnID) {
-	msg, err := td.Producer.MultiSigCancel(ms, from, nonce, txID, chain.Value(value))
+	msg, err := td.Producer.MultiSigCancel(ms, from, txID, chain.Value(value), chain.Nonce(nonce))
 	require.NoError(td.T, err)
 
 	msgReceipt, err := td.Validator.ApplyMessage(td.ExeCtx, td.Driver.State(), msg)

--- a/pkg/suites/transfer.go
+++ b/pkg/suites/transfer.go
@@ -26,8 +26,7 @@ func AccountValueTransferSuccess(t *testing.T, factory Factories) {
 	alice := td.Driver.NewAccountActor(SECP, aliceBal)
 	bob := td.Driver.NewAccountActor(SECP, bobBal)
 
-	msg, err := td.Producer.Transfer(alice, bob, 0, transferValue)
-	require.NoError(t, err)
+	msg := td.Producer.Transfer(bob, alice, chain.Value(transferValue), chain.Nonce(0))
 
 	msgReceipt, err := td.Validator.ApplyMessage(td.ExeCtx, td.Driver.State(), msg)
 	require.NoError(t, err)
@@ -55,8 +54,7 @@ func AccountValueTransferZeroFunds(t *testing.T, factory Factories) {
 	alice := td.Driver.NewAccountActor(SECP, aliceBal)
 	bob := td.Driver.NewAccountActor(SECP, bobBal)
 
-	msg, err := td.Producer.Transfer(alice, bob, 0, transferValue)
-	require.NoError(t, err)
+	msg := td.Producer.Transfer(bob, alice, chain.Value(transferValue), chain.Nonce(0))
 
 	msgReceipt, err := td.Validator.ApplyMessage(td.ExeCtx, td.Driver.State(), msg)
 	require.NoError(t, err)
@@ -84,8 +82,7 @@ func AccountValueTransferOverBalanceNonZero(t *testing.T, factory Factories) {
 	alice := td.Driver.NewAccountActor(SECP, aliceBal)
 	bob := td.Driver.NewAccountActor(SECP, bobBal)
 
-	msg, err := td.Producer.Transfer(alice, bob, 0, transferAmnt)
-	require.NoError(t, err)
+	msg := td.Producer.Transfer(bob, alice, chain.Value(transferAmnt), chain.Nonce(0))
 
 	msgReceipt, err := td.Validator.ApplyMessage(td.ExeCtx, td.Driver.State(), msg)
 	require.Error(t, err)
@@ -113,8 +110,7 @@ func AccountValueTransferOverBalanceZero(t *testing.T, factory Factories) {
 	alice := td.Driver.NewAccountActor(SECP, aliceBal)
 	bob := td.Driver.NewAccountActor(SECP, bobBal)
 
-	msg, err := td.Producer.Transfer(alice, bob, 0, transferAmnt)
-	require.NoError(t, err)
+	msg := td.Producer.Transfer(bob, alice, chain.Value(transferAmnt), chain.Nonce(0))
 
 	msgReceipt, err := td.Validator.ApplyMessage(td.ExeCtx, td.Driver.State(), msg)
 	require.Error(t, err)
@@ -140,8 +136,7 @@ func AccountValueTransferToSelf(t *testing.T, factory Factories) {
 
 	alice := td.Driver.NewAccountActor(SECP, aliceBal)
 
-	msg, err := td.Producer.Transfer(alice, alice, 0, transferAmnt)
-	require.NoError(t, err)
+	msg := td.Producer.Transfer(alice, alice, chain.Value(transferAmnt), chain.Nonce(0))
 
 	msgReceipt, err := td.Validator.ApplyMessage(td.ExeCtx, td.Driver.State(), msg)
 	require.Error(t, err)
@@ -168,8 +163,7 @@ func AccountValueTransferFromKnownToUnknownAccount(t *testing.T, factory Factori
 
 	unknown := td.Driver.State().NewSecp256k1AccountAddress()
 
-	msg, err := td.Producer.Transfer(alice, unknown, 0, transferAmnt)
-	require.NoError(t, err)
+	msg := td.Producer.Transfer(unknown, alice, chain.Value(transferAmnt), chain.Nonce(0))
 
 	msgReceipt, err := td.Validator.ApplyMessage(td.ExeCtx, td.Driver.State(), msg)
 	require.Error(t, err)
@@ -195,8 +189,7 @@ func AccountValueTransferFromUnknownToKnownAccount(t *testing.T, factory Factori
 	alice := td.Driver.NewAccountActor(SECP, aliceBal)
 	unknown := td.Driver.State().NewSecp256k1AccountAddress()
 
-	msg, err := td.Producer.Transfer(unknown, alice, 0, transferAmnt)
-	require.NoError(t, err)
+	msg := td.Producer.Transfer(alice, unknown, chain.Value(transferAmnt), chain.Nonce(0))
 
 	msgReceipt, err := td.Validator.ApplyMessage(td.ExeCtx, td.Driver.State(), msg)
 	require.Error(t, err)
@@ -221,8 +214,7 @@ func AccountValueTransferFromUnknownToUnknownAccount(t *testing.T, factory Facto
 	unknown := td.Driver.State().NewSecp256k1AccountAddress()
 	nobody := td.Driver.State().NewSecp256k1AccountAddress()
 
-	msg, err := td.Producer.Transfer(unknown, nobody, 0, transferAmnt)
-	require.NoError(t, err)
+	msg := td.Producer.Transfer(nobody, unknown, chain.Value(transferAmnt), chain.Nonce(0))
 
 	msgReceipt, err := td.Validator.ApplyMessage(td.ExeCtx, td.Driver.State(), msg)
 	require.Error(t, err)


### PR DESCRIPTION
- standardize to and from order in message producer methods
- don't return error from message builder
- nonce is message functional argument