### PR TITLE
remove errors from message producers

### DIFF
--- a/gen/gen.go
+++ b/gen/gen.go
@@ -133,13 +133,9 @@ func MakeMethods(jenFile *jen.File, details GenDetails) {
 			jen.Id("opts").Id("...MsgOpt"),
 		).Params(
 			jen.Id("*Message"),
-			jen.Id("error"),
 		).Block(
-			jen.List(jen.Id("ser"), jen.Err()).Op(":=").Id("state.Serialize").Call(jen.Id("&params")),
-			jen.If(jen.Id("err").Op("!=").Id("nil")).Block(
-				jen.Return(jen.Id("nil"), jen.Id("err")),
-			),
-			jen.Return(jen.Id("mp.Build").Params(jen.Id("to"), jen.Id("from"), jen.Id(fmt.Sprintf("builtin_spec.Methods%s", d.methodPrefix)), jen.Id("ser"), jen.Id("opts...")), jen.Nil()),
+			jen.Id("ser").Op(":=").Id("state.MustSerialize").Call(jen.Id("&params")),
+			jen.Return(jen.Id("mp.Build").Params(jen.Id("to"), jen.Id("from"), jen.Id(fmt.Sprintf("builtin_spec.Methods%s", d.methodPrefix)), jen.Id("ser"), jen.Id("opts..."))),
 		)
 	}
 }

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,7 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/aead/siphash v1.0.1 h1:FwHfE/T45KPKYuuSAKyyvE+oPWcaQ+CUmFW0bPlM+kg=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
 github.com/btcsuite/btcd v0.20.1-beta h1:Ik4hyJqN8Jfyv3S4AGBOmyouMsYE3EdYODkMbQjwPGw=
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
@@ -111,6 +112,7 @@ github.com/kami-zh/go-capturer v0.0.0-20171211120116-e492ea43421d/go.mod h1:P2vi
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23 h1:FOOIBWrEkLgmlgGfMuZT83xIwfPDxEI2OHu6xUmJMFE=
 github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23/go.mod h1:J+Gs4SYgM6CZQHDETBtE9HaSEkGmuNXF86RwHhHUvq4=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=

--- a/pkg/chain/account.go
+++ b/pkg/chain/account.go
@@ -8,18 +8,11 @@ import (
 	"github.com/filecoin-project/chain-validation/pkg/state"
 )
 
-func (mp *MessageProducer) AccountConstructor(to, from address.Address, params address.Address, opts ...MsgOpt) (*Message, error) {
-	ser, err := state.Serialize(&params)
-	if err != nil {
-		return nil, err
-	}
-	return mp.Build(to, from, builtin_spec.MethodsAccount.Constructor, ser, opts...), nil
+func (mp *MessageProducer) AccountConstructor(to, from address.Address, params address.Address, opts ...MsgOpt) *Message {
+	ser := state.MustSerialize(&params)
+	return mp.Build(to, from, builtin_spec.MethodsAccount.Constructor, ser, opts...)
 }
-
-func (mp *MessageProducer) AccountPubkeyAddress(to, from address.Address, params adt.EmptyValue, opts ...MsgOpt) (*Message, error) {
-	ser, err := state.Serialize(&params)
-	if err != nil {
-		return nil, err
-	}
-	return mp.Build(to, from, builtin_spec.MethodsAccount.Constructor, ser, opts...), nil
+func (mp *MessageProducer) AccountPubkeyAddress(to, from address.Address, params adt.EmptyValue, opts ...MsgOpt) *Message {
+	ser := state.MustSerialize(&params)
+	return mp.Build(to, from, builtin_spec.MethodsAccount.PubkeyAddress, ser, opts...)
 }

--- a/pkg/chain/cron.go
+++ b/pkg/chain/cron.go
@@ -9,18 +9,11 @@ import (
 	"github.com/filecoin-project/chain-validation/pkg/state"
 )
 
-func (mp *MessageProducer) CronConstructor(to, from address.Address, params cron.ConstructorParams, opts ...MsgOpt) (*Message, error) {
-	ser, err := state.Serialize(&params)
-	if err != nil {
-		return nil, err
-	}
-	return mp.Build(to, from, builtin_spec.MethodsCron.Constructor, ser, opts...), nil
+func (mp *MessageProducer) CronConstructor(to, from address.Address, params cron.ConstructorParams, opts ...MsgOpt) *Message {
+	ser := state.MustSerialize(&params)
+	return mp.Build(to, from, builtin_spec.MethodsCron.Constructor, ser, opts...)
 }
-
-func (mp *MessageProducer) CronEpochTick(to, from address.Address, params adt.EmptyValue, opts ...MsgOpt) (*Message, error) {
-	ser, err := state.Serialize(&params)
-	if err != nil {
-		return nil, err
-	}
-	return mp.Build(to, from, builtin_spec.MethodsCron.EpochTick, ser, opts...), nil
+func (mp *MessageProducer) CronEpochTick(to, from address.Address, params adt.EmptyValue, opts ...MsgOpt) *Message {
+	ser := state.MustSerialize(&params)
+	return mp.Build(to, from, builtin_spec.MethodsCron.EpochTick, ser, opts...)
 }

--- a/pkg/chain/init_.go
+++ b/pkg/chain/init_.go
@@ -9,18 +9,11 @@ import (
 	"github.com/filecoin-project/chain-validation/pkg/state"
 )
 
-func (mp *MessageProducer) InitConstructor(to, from address.Address, params adt.EmptyValue, opts ...MsgOpt) (*Message, error) {
-	ser, err := state.Serialize(&params)
-	if err != nil {
-		return nil, err
-	}
-	return mp.Build(to, from, builtin_spec.MethodsInit.Constructor, ser, opts...), nil
+func (mp *MessageProducer) InitConstructor(to, from address.Address, params adt.EmptyValue, opts ...MsgOpt) *Message {
+	ser := state.MustSerialize(&params)
+	return mp.Build(to, from, builtin_spec.MethodsInit.Constructor, ser, opts...)
 }
-
-func (mp *MessageProducer) InitExec(to, from address.Address, params init_.ExecParams, opts ...MsgOpt) (*Message, error) {
-	ser, err := state.Serialize(&params)
-	if err != nil {
-		return nil, err
-	}
-	return mp.Build(to, from, builtin_spec.MethodsInit.Exec, ser, opts...), nil
+func (mp *MessageProducer) InitExec(to, from address.Address, params init_.ExecParams, opts ...MsgOpt) *Message {
+	ser := state.MustSerialize(&params)
+	return mp.Build(to, from, builtin_spec.MethodsInit.Exec, ser, opts...)
 }

--- a/pkg/chain/market.go
+++ b/pkg/chain/market.go
@@ -9,70 +9,38 @@ import (
 	"github.com/filecoin-project/chain-validation/pkg/state"
 )
 
-func (mp *MessageProducer) MarketConstructor(to, from address.Address, params adt.EmptyValue, opts ...MsgOpt) (*Message, error) {
-	ser, err := state.Serialize(&params)
-	if err != nil {
-		return nil, err
-	}
-	return mp.Build(to, from, builtin_spec.MethodsMarket.Constructor, ser, opts...), nil
+func (mp *MessageProducer) MarketConstructor(to, from address.Address, params adt.EmptyValue, opts ...MsgOpt) *Message {
+	ser := state.MustSerialize(&params)
+	return mp.Build(to, from, builtin_spec.MethodsMarket.Constructor, ser, opts...)
 }
-
-func (mp *MessageProducer) MarketAddBalance(to, from address.Address, params address.Address, opts ...MsgOpt) (*Message, error) {
-	ser, err := state.Serialize(&params)
-	if err != nil {
-		return nil, err
-	}
-	return mp.Build(to, from, builtin_spec.MethodsMarket.AddBalance, ser, opts...), nil
+func (mp *MessageProducer) MarketAddBalance(to, from address.Address, params address.Address, opts ...MsgOpt) *Message {
+	ser := state.MustSerialize(&params)
+	return mp.Build(to, from, builtin_spec.MethodsMarket.AddBalance, ser, opts...)
 }
-
-func (mp *MessageProducer) MarketWithdrawBalance(to, from address.Address, params market.WithdrawBalanceParams, opts ...MsgOpt) (*Message, error) {
-	ser, err := state.Serialize(&params)
-	if err != nil {
-		return nil, err
-	}
-	return mp.Build(to, from, builtin_spec.MethodsMarket.WithdrawBalance, ser, opts...), nil
+func (mp *MessageProducer) MarketWithdrawBalance(to, from address.Address, params market.WithdrawBalanceParams, opts ...MsgOpt) *Message {
+	ser := state.MustSerialize(&params)
+	return mp.Build(to, from, builtin_spec.MethodsMarket.WithdrawBalance, ser, opts...)
 }
-
-func (mp *MessageProducer) MarketHandleExpiredDeals(to, from address.Address, params market.HandleExpiredDealsParams, opts ...MsgOpt) (*Message, error) {
-	// FIXME params does not fulfill cbor marshal interface
+func (mp *MessageProducer) MarketHandleExpiredDeals(to, from address.Address, params market.HandleExpiredDealsParams, opts ...MsgOpt) *Message {
 	panic("TODO HandleExpiredDealsParams does not implement a CBOR marshaller")
 	/*
-		ser, err := state.Serialize(&params)
-		if err != nil {
-			return nil, err
-		}
-		return mp.Build(to, from, builtin_spec.MethodsMarket.HandleExpiredDeals, ser, opts...), nil
+		ser := state.MustSerialize(&params)
+		return mp.Build(to, from, builtin_spec.MethodsMarket.HandleExpiredDeals, ser, opts...)
 	*/
 }
-
-func (mp *MessageProducer) MarketPublishStorageDeals(to, from address.Address, params market.PublishStorageDealsParams, opts ...MsgOpt) (*Message, error) {
-	ser, err := state.Serialize(&params)
-	if err != nil {
-		return nil, err
-	}
-	return mp.Build(to, from, builtin_spec.MethodsMarket.PublishStorageDeals, ser, opts...), nil
+func (mp *MessageProducer) MarketPublishStorageDeals(to, from address.Address, params market.PublishStorageDealsParams, opts ...MsgOpt) *Message {
+	ser := state.MustSerialize(&params)
+	return mp.Build(to, from, builtin_spec.MethodsMarket.PublishStorageDeals, ser, opts...)
 }
-
-func (mp *MessageProducer) MarketVerifyDealsOnSectorProveCommit(to, from address.Address, params market.VerifyDealsOnSectorProveCommitParams, opts ...MsgOpt) (*Message, error) {
-	ser, err := state.Serialize(&params)
-	if err != nil {
-		return nil, err
-	}
-	return mp.Build(to, from, builtin_spec.MethodsMarket.VerifyDealsOnSectorProveCommit, ser, opts...), nil
+func (mp *MessageProducer) MarketVerifyDealsOnSectorProveCommit(to, from address.Address, params market.VerifyDealsOnSectorProveCommitParams, opts ...MsgOpt) *Message {
+	ser := state.MustSerialize(&params)
+	return mp.Build(to, from, builtin_spec.MethodsMarket.VerifyDealsOnSectorProveCommit, ser, opts...)
 }
-
-func (mp *MessageProducer) MarketOnMinerSectorsTerminate(to, from address.Address, params market.OnMinerSectorsTerminateParams, opts ...MsgOpt) (*Message, error) {
-	ser, err := state.Serialize(&params)
-	if err != nil {
-		return nil, err
-	}
-	return mp.Build(to, from, builtin_spec.MethodsMarket.OnMinerSectorsTerminate, ser, opts...), nil
+func (mp *MessageProducer) MarketOnMinerSectorsTerminate(to, from address.Address, params market.OnMinerSectorsTerminateParams, opts ...MsgOpt) *Message {
+	ser := state.MustSerialize(&params)
+	return mp.Build(to, from, builtin_spec.MethodsMarket.OnMinerSectorsTerminate, ser, opts...)
 }
-
-func (mp *MessageProducer) MarketComputeDataCommitment(to, from address.Address, params market.ComputeDataCommitmentParams, opts ...MsgOpt) (*Message, error) {
-	ser, err := state.Serialize(&params)
-	if err != nil {
-		return nil, err
-	}
-	return mp.Build(to, from, builtin_spec.MethodsMarket.ComputeDataCommitment, ser, opts...), nil
+func (mp *MessageProducer) MarketComputeDataCommitment(to, from address.Address, params market.ComputeDataCommitmentParams, opts ...MsgOpt) *Message {
+	ser := state.MustSerialize(&params)
+	return mp.Build(to, from, builtin_spec.MethodsMarket.ComputeDataCommitment, ser, opts...)
 }

--- a/pkg/chain/miner.go
+++ b/pkg/chain/miner.go
@@ -10,106 +10,55 @@ import (
 	"github.com/filecoin-project/chain-validation/pkg/state"
 )
 
-func (mp *MessageProducer) MinerConstructor(to, from address.Address, params power.MinerConstructorParams, opts ...MsgOpt) (*Message, error) {
-	ser, err := state.Serialize(&params)
-	if err != nil {
-		return nil, err
-	}
-	return mp.Build(to, from, builtin_spec.MethodsMiner.Constructor, ser, opts...), nil
+func (mp *MessageProducer) MinerConstructor(to, from address.Address, params power.MinerConstructorParams, opts ...MsgOpt) *Message {
+	ser := state.MustSerialize(&params)
+	return mp.Build(to, from, builtin_spec.MethodsMiner.Constructor, ser, opts...)
 }
-
-func (mp *MessageProducer) MinerControlAddresses(to, from address.Address, params adt.EmptyValue, opts ...MsgOpt) (*Message, error) {
-	ser, err := state.Serialize(&params)
-	if err != nil {
-		return nil, err
-	}
-	return mp.Build(to, from, builtin_spec.MethodsMiner.ControlAddresses, ser, opts...), nil
+func (mp *MessageProducer) MinerControlAddresses(to, from address.Address, params adt.EmptyValue, opts ...MsgOpt) *Message {
+	ser := state.MustSerialize(&params)
+	return mp.Build(to, from, builtin_spec.MethodsMiner.ControlAddresses, ser, opts...)
 }
-
-func (mp *MessageProducer) MinerChangeWorkerAddress(to, from address.Address, params miner.ChangeWorkerAddressParams, opts ...MsgOpt) (*Message, error) {
-	ser, err := state.Serialize(&params)
-	if err != nil {
-		return nil, err
-	}
-	return mp.Build(to, from, builtin_spec.MethodsMiner.ChangeWorkerAddress, ser, opts...), nil
+func (mp *MessageProducer) MinerChangeWorkerAddress(to, from address.Address, params miner.ChangeWorkerAddressParams, opts ...MsgOpt) *Message {
+	ser := state.MustSerialize(&params)
+	return mp.Build(to, from, builtin_spec.MethodsMiner.ChangeWorkerAddress, ser, opts...)
 }
-
-func (mp *MessageProducer) MinerOnSurprisePoStChallenge(to, from address.Address, params adt.EmptyValue, opts ...MsgOpt) (*Message, error) {
-	ser, err := state.Serialize(&params)
-	if err != nil {
-		return nil, err
-	}
-	return mp.Build(to, from, builtin_spec.MethodsMiner.OnSurprisePoStChallenge, ser, opts...), nil
+func (mp *MessageProducer) MinerOnSurprisePoStChallenge(to, from address.Address, params adt.EmptyValue, opts ...MsgOpt) *Message {
+	ser := state.MustSerialize(&params)
+	return mp.Build(to, from, builtin_spec.MethodsMiner.OnSurprisePoStChallenge, ser, opts...)
 }
-
-func (mp *MessageProducer) MinerSubmitSurprisePoStResponse(to, from address.Address, params miner.SubmitSurprisePoStResponseParams, opts ...MsgOpt) (*Message, error) {
-	ser, err := state.Serialize(&params)
-	if err != nil {
-		return nil, err
-	}
-	return mp.Build(to, from, builtin_spec.MethodsMiner.SubmitSurprisePoStResponse, ser, opts...), nil
+func (mp *MessageProducer) MinerSubmitSurprisePoStResponse(to, from address.Address, params miner.SubmitSurprisePoStResponseParams, opts ...MsgOpt) *Message {
+	ser := state.MustSerialize(&params)
+	return mp.Build(to, from, builtin_spec.MethodsMiner.SubmitSurprisePoStResponse, ser, opts...)
 }
-
-func (mp *MessageProducer) MinerOnDeleteMiner(to, from address.Address, params adt.EmptyValue, opts ...MsgOpt) (*Message, error) {
-	ser, err := state.Serialize(&params)
-	if err != nil {
-		return nil, err
-	}
-	return mp.Build(to, from, builtin_spec.MethodsMiner.OnDeleteMiner, ser, opts...), nil
+func (mp *MessageProducer) MinerOnDeleteMiner(to, from address.Address, params adt.EmptyValue, opts ...MsgOpt) *Message {
+	ser := state.MustSerialize(&params)
+	return mp.Build(to, from, builtin_spec.MethodsMiner.OnDeleteMiner, ser, opts...)
 }
-
-func (mp *MessageProducer) MinerOnVerifiedElectionPoSt(to, from address.Address, params adt.EmptyValue, opts ...MsgOpt) (*Message, error) {
-	ser, err := state.Serialize(&params)
-	if err != nil {
-		return nil, err
-	}
-	return mp.Build(to, from, builtin_spec.MethodsMiner.OnVerifiedElectionPoSt, ser, opts...), nil
+func (mp *MessageProducer) MinerOnVerifiedElectionPoSt(to, from address.Address, params adt.EmptyValue, opts ...MsgOpt) *Message {
+	ser := state.MustSerialize(&params)
+	return mp.Build(to, from, builtin_spec.MethodsMiner.OnVerifiedElectionPoSt, ser, opts...)
 }
-
-func (mp *MessageProducer) MinerPreCommitSector(to, from address.Address, params miner.PreCommitSectorParams, opts ...MsgOpt) (*Message, error) {
-	ser, err := state.Serialize(&params)
-	if err != nil {
-		return nil, err
-	}
-	return mp.Build(to, from, builtin_spec.MethodsMiner.PreCommitSector, ser, opts...), nil
+func (mp *MessageProducer) MinerPreCommitSector(to, from address.Address, params miner.PreCommitSectorParams, opts ...MsgOpt) *Message {
+	ser := state.MustSerialize(&params)
+	return mp.Build(to, from, builtin_spec.MethodsMiner.PreCommitSector, ser, opts...)
 }
-
-func (mp *MessageProducer) MinerProveCommitSector(to, from address.Address, params miner.ProveCommitSectorParams, opts ...MsgOpt) (*Message, error) {
-	ser, err := state.Serialize(&params)
-	if err != nil {
-		return nil, err
-	}
-	return mp.Build(to, from, builtin_spec.MethodsMiner.ProveCommitSector, ser, opts...), nil
+func (mp *MessageProducer) MinerProveCommitSector(to, from address.Address, params miner.ProveCommitSectorParams, opts ...MsgOpt) *Message {
+	ser := state.MustSerialize(&params)
+	return mp.Build(to, from, builtin_spec.MethodsMiner.ProveCommitSector, ser, opts...)
 }
-
-func (mp *MessageProducer) MinerExtendSectorExpiration(to, from address.Address, params miner.ExtendSectorExpirationParams, opts ...MsgOpt) (*Message, error) {
-	ser, err := state.Serialize(&params)
-	if err != nil {
-		return nil, err
-	}
-	return mp.Build(to, from, builtin_spec.MethodsMiner.ExtendSectorExpiration, ser, opts...), nil
+func (mp *MessageProducer) MinerExtendSectorExpiration(to, from address.Address, params miner.ExtendSectorExpirationParams, opts ...MsgOpt) *Message {
+	ser := state.MustSerialize(&params)
+	return mp.Build(to, from, builtin_spec.MethodsMiner.ExtendSectorExpiration, ser, opts...)
 }
-
-func (mp *MessageProducer) MinerTerminateSectors(to, from address.Address, params miner.TerminateSectorsParams, opts ...MsgOpt) (*Message, error) {
-	ser, err := state.Serialize(&params)
-	if err != nil {
-		return nil, err
-	}
-	return mp.Build(to, from, builtin_spec.MethodsMiner.TerminateSectors, ser, opts...), nil
+func (mp *MessageProducer) MinerTerminateSectors(to, from address.Address, params miner.TerminateSectorsParams, opts ...MsgOpt) *Message {
+	ser := state.MustSerialize(&params)
+	return mp.Build(to, from, builtin_spec.MethodsMiner.TerminateSectors, ser, opts...)
 }
-
-func (mp *MessageProducer) MinerDeclareTemporaryFaults(to, from address.Address, params miner.DeclareTemporaryFaultsParams, opts ...MsgOpt) (*Message, error) {
-	ser, err := state.Serialize(&params)
-	if err != nil {
-		return nil, err
-	}
-	return mp.Build(to, from, builtin_spec.MethodsMiner.DeclareTemporaryFaults, ser, opts...), nil
+func (mp *MessageProducer) MinerDeclareTemporaryFaults(to, from address.Address, params miner.DeclareTemporaryFaultsParams, opts ...MsgOpt) *Message {
+	ser := state.MustSerialize(&params)
+	return mp.Build(to, from, builtin_spec.MethodsMiner.DeclareTemporaryFaults, ser, opts...)
 }
-
-func (mp *MessageProducer) MinerOnDeferredCronEvent(to, from address.Address, params miner.OnDeferredCronEventParams, opts ...MsgOpt) (*Message, error) {
-	ser, err := state.Serialize(&params)
-	if err != nil {
-		return nil, err
-	}
-	return mp.Build(to, from, builtin_spec.MethodsMiner.OnDeferredCronEvent, ser, opts...), nil
+func (mp *MessageProducer) MinerOnDeferredCronEvent(to, from address.Address, params miner.OnDeferredCronEventParams, opts ...MsgOpt) *Message {
+	ser := state.MustSerialize(&params)
+	return mp.Build(to, from, builtin_spec.MethodsMiner.OnDeferredCronEvent, ser, opts...)
 }

--- a/pkg/chain/multisig.go
+++ b/pkg/chain/multisig.go
@@ -8,66 +8,35 @@ import (
 	"github.com/filecoin-project/chain-validation/pkg/state"
 )
 
-func (mp *MessageProducer) MultisigConstructor(to, from address.Address, params multisig.ConstructorParams, opts ...MsgOpt) (*Message, error) {
-	ser, err := state.Serialize(&params)
-	if err != nil {
-		return nil, err
-	}
-	return mp.Build(to, from, builtin_spec.MethodsMultisig.Constructor, ser, opts...), nil
+func (mp *MessageProducer) MultisigConstructor(to, from address.Address, params multisig.ConstructorParams, opts ...MsgOpt) *Message {
+	ser := state.MustSerialize(&params)
+	return mp.Build(to, from, builtin_spec.MethodsMultisig.Constructor, ser, opts...)
 }
-
-func (mp *MessageProducer) MultisigPropose(to, from address.Address, params multisig.ProposeParams, opts ...MsgOpt) (*Message, error) {
-	ser, err := state.Serialize(&params)
-	if err != nil {
-		return nil, err
-	}
-	return mp.Build(to, from, builtin_spec.MethodsMultisig.Propose, ser, opts...), nil
+func (mp *MessageProducer) MultisigPropose(to, from address.Address, params multisig.ProposeParams, opts ...MsgOpt) *Message {
+	ser := state.MustSerialize(&params)
+	return mp.Build(to, from, builtin_spec.MethodsMultisig.Propose, ser, opts...)
 }
-
-func (mp *MessageProducer) MultisigApprove(to, from address.Address, params multisig.TxnIDParams, opts ...MsgOpt) (*Message, error) {
-	ser, err := state.Serialize(&params)
-	if err != nil {
-		return nil, err
-	}
-	return mp.Build(to, from, builtin_spec.MethodsMultisig.Approve, ser, opts...), nil
+func (mp *MessageProducer) MultisigApprove(to, from address.Address, params multisig.TxnIDParams, opts ...MsgOpt) *Message {
+	ser := state.MustSerialize(&params)
+	return mp.Build(to, from, builtin_spec.MethodsMultisig.Approve, ser, opts...)
 }
-
-func (mp *MessageProducer) MultisigCancel(to, from address.Address, params multisig.TxnIDParams, opts ...MsgOpt) (*Message, error) {
-	ser, err := state.Serialize(&params)
-	if err != nil {
-		return nil, err
-	}
-	return mp.Build(to, from, builtin_spec.MethodsMultisig.Cancel, ser, opts...), nil
+func (mp *MessageProducer) MultisigCancel(to, from address.Address, params multisig.TxnIDParams, opts ...MsgOpt) *Message {
+	ser := state.MustSerialize(&params)
+	return mp.Build(to, from, builtin_spec.MethodsMultisig.Cancel, ser, opts...)
 }
-
-func (mp *MessageProducer) MultisigAddSigner(to, from address.Address, params multisig.AddSignerParams, opts ...MsgOpt) (*Message, error) {
-	ser, err := state.Serialize(&params)
-	if err != nil {
-		return nil, err
-	}
-	return mp.Build(to, from, builtin_spec.MethodsMultisig.AddSigner, ser, opts...), nil
+func (mp *MessageProducer) MultisigAddSigner(to, from address.Address, params multisig.AddSignerParams, opts ...MsgOpt) *Message {
+	ser := state.MustSerialize(&params)
+	return mp.Build(to, from, builtin_spec.MethodsMultisig.AddSigner, ser, opts...)
 }
-
-func (mp *MessageProducer) MultisigRemoveSigner(to, from address.Address, params multisig.RemoveSignerParams, opts ...MsgOpt) (*Message, error) {
-	ser, err := state.Serialize(&params)
-	if err != nil {
-		return nil, err
-	}
-	return mp.Build(to, from, builtin_spec.MethodsMultisig.RemoveSigner, ser, opts...), nil
+func (mp *MessageProducer) MultisigRemoveSigner(to, from address.Address, params multisig.RemoveSignerParams, opts ...MsgOpt) *Message {
+	ser := state.MustSerialize(&params)
+	return mp.Build(to, from, builtin_spec.MethodsMultisig.RemoveSigner, ser, opts...)
 }
-
-func (mp *MessageProducer) MultisigSwapSigner(to, from address.Address, params multisig.SwapSignerParams, opts ...MsgOpt) (*Message, error) {
-	ser, err := state.Serialize(&params)
-	if err != nil {
-		return nil, err
-	}
-	return mp.Build(to, from, builtin_spec.MethodsMultisig.SwapSigner, ser, opts...), nil
+func (mp *MessageProducer) MultisigSwapSigner(to, from address.Address, params multisig.SwapSignerParams, opts ...MsgOpt) *Message {
+	ser := state.MustSerialize(&params)
+	return mp.Build(to, from, builtin_spec.MethodsMultisig.SwapSigner, ser, opts...)
 }
-
-func (mp *MessageProducer) MultisigChangeNumApprovalsThreshold(to, from address.Address, params multisig.ChangeNumApprovalsThresholdParams, opts ...MsgOpt) (*Message, error) {
-	ser, err := state.Serialize(&params)
-	if err != nil {
-		return nil, err
-	}
-	return mp.Build(to, from, builtin_spec.MethodsMultisig.ChangeNumApprovalsThreshold, ser, opts...), nil
+func (mp *MessageProducer) MultisigChangeNumApprovalsThreshold(to, from address.Address, params multisig.ChangeNumApprovalsThresholdParams, opts ...MsgOpt) *Message {
+	ser := state.MustSerialize(&params)
+	return mp.Build(to, from, builtin_spec.MethodsMultisig.ChangeNumApprovalsThreshold, ser, opts...)
 }

--- a/pkg/chain/paych.go
+++ b/pkg/chain/paych.go
@@ -9,34 +9,19 @@ import (
 	"github.com/filecoin-project/chain-validation/pkg/state"
 )
 
-func (mp *MessageProducer) PaychConstructor(to, from address.Address, params paych.ConstructorParams, opts ...MsgOpt) (*Message, error) {
-	ser, err := state.Serialize(&params)
-	if err != nil {
-		return nil, err
-	}
-	return mp.Build(to, from, builtin_spec.MethodsPaych.Constructor, ser, opts...), nil
+func (mp *MessageProducer) PaychConstructor(to, from address.Address, params paych.ConstructorParams, opts ...MsgOpt) *Message {
+	ser := state.MustSerialize(&params)
+	return mp.Build(to, from, builtin_spec.MethodsPaych.Constructor, ser, opts...)
 }
-
-func (mp *MessageProducer) PaychUpdateChannelState(to, from address.Address, params paych.UpdateChannelStateParams, opts ...MsgOpt) (*Message, error) {
-	ser, err := state.Serialize(&params)
-	if err != nil {
-		return nil, err
-	}
-	return mp.Build(to, from, builtin_spec.MethodsPaych.UpdateChannelState, ser, opts...), nil
+func (mp *MessageProducer) PaychUpdateChannelState(to, from address.Address, params paych.UpdateChannelStateParams, opts ...MsgOpt) *Message {
+	ser := state.MustSerialize(&params)
+	return mp.Build(to, from, builtin_spec.MethodsPaych.UpdateChannelState, ser, opts...)
 }
-
-func (mp *MessageProducer) PaychSettle(to, from address.Address, params adt.EmptyValue, opts ...MsgOpt) (*Message, error) {
-	ser, err := state.Serialize(&params)
-	if err != nil {
-		return nil, err
-	}
-	return mp.Build(to, from, builtin_spec.MethodsPaych.Settle, ser, opts...), nil
+func (mp *MessageProducer) PaychSettle(to, from address.Address, params adt.EmptyValue, opts ...MsgOpt) *Message {
+	ser := state.MustSerialize(&params)
+	return mp.Build(to, from, builtin_spec.MethodsPaych.Settle, ser, opts...)
 }
-
-func (mp *MessageProducer) PaychCollect(to, from address.Address, params adt.EmptyValue, opts ...MsgOpt) (*Message, error) {
-	ser, err := state.Serialize(&params)
-	if err != nil {
-		return nil, err
-	}
-	return mp.Build(to, from, builtin_spec.MethodsPaych.Collect, ser, opts...), nil
+func (mp *MessageProducer) PaychCollect(to, from address.Address, params adt.EmptyValue, opts ...MsgOpt) *Message {
+	ser := state.MustSerialize(&params)
+	return mp.Build(to, from, builtin_spec.MethodsPaych.Collect, ser, opts...)
 }

--- a/pkg/chain/power.go
+++ b/pkg/chain/power.go
@@ -9,122 +9,63 @@ import (
 	"github.com/filecoin-project/chain-validation/pkg/state"
 )
 
-func (mp *MessageProducer) PowerConstructor(to, from address.Address, params adt.EmptyValue, opts ...MsgOpt) (*Message, error) {
-	ser, err := state.Serialize(&params)
-	if err != nil {
-		return nil, err
-	}
-	return mp.Build(to, from, builtin_spec.MethodsPower.Constructor, ser, opts...), nil
+func (mp *MessageProducer) PowerConstructor(to, from address.Address, params adt.EmptyValue, opts ...MsgOpt) *Message {
+	ser := state.MustSerialize(&params)
+	return mp.Build(to, from, builtin_spec.MethodsPower.Constructor, ser, opts...)
 }
-
-func (mp *MessageProducer) PowerAddBalance(to, from address.Address, params power.AddBalanceParams, opts ...MsgOpt) (*Message, error) {
-	ser, err := state.Serialize(&params)
-	if err != nil {
-		return nil, err
-	}
-	return mp.Build(to, from, builtin_spec.MethodsPower.AddBalance, ser, opts...), nil
+func (mp *MessageProducer) PowerAddBalance(to, from address.Address, params power.AddBalanceParams, opts ...MsgOpt) *Message {
+	ser := state.MustSerialize(&params)
+	return mp.Build(to, from, builtin_spec.MethodsPower.AddBalance, ser, opts...)
 }
-
-func (mp *MessageProducer) PowerWithdrawBalance(to, from address.Address, params power.WithdrawBalanceParams, opts ...MsgOpt) (*Message, error) {
-	ser, err := state.Serialize(&params)
-	if err != nil {
-		return nil, err
-	}
-	return mp.Build(to, from, builtin_spec.MethodsPower.WithdrawBalance, ser, opts...), nil
+func (mp *MessageProducer) PowerWithdrawBalance(to, from address.Address, params power.WithdrawBalanceParams, opts ...MsgOpt) *Message {
+	ser := state.MustSerialize(&params)
+	return mp.Build(to, from, builtin_spec.MethodsPower.WithdrawBalance, ser, opts...)
 }
-
-func (mp *MessageProducer) PowerCreateMiner(to, from address.Address, params power.CreateMinerParams, opts ...MsgOpt) (*Message, error) {
-	ser, err := state.Serialize(&params)
-	if err != nil {
-		return nil, err
-	}
-	return mp.Build(to, from, builtin_spec.MethodsPower.CreateMiner, ser, opts...), nil
+func (mp *MessageProducer) PowerCreateMiner(to, from address.Address, params power.CreateMinerParams, opts ...MsgOpt) *Message {
+	ser := state.MustSerialize(&params)
+	return mp.Build(to, from, builtin_spec.MethodsPower.CreateMiner, ser, opts...)
 }
-
-func (mp *MessageProducer) PowerDeleteMiner(to, from address.Address, params power.DeleteMinerParams, opts ...MsgOpt) (*Message, error) {
-	ser, err := state.Serialize(&params)
-	if err != nil {
-		return nil, err
-	}
-	return mp.Build(to, from, builtin_spec.MethodsPower.DeleteMiner, ser, opts...), nil
+func (mp *MessageProducer) PowerDeleteMiner(to, from address.Address, params power.DeleteMinerParams, opts ...MsgOpt) *Message {
+	ser := state.MustSerialize(&params)
+	return mp.Build(to, from, builtin_spec.MethodsPower.DeleteMiner, ser, opts...)
 }
-
-func (mp *MessageProducer) PowerOnSectorProveCommit(to, from address.Address, params power.OnSectorProveCommitParams, opts ...MsgOpt) (*Message, error) {
-	ser, err := state.Serialize(&params)
-	if err != nil {
-		return nil, err
-	}
-	return mp.Build(to, from, builtin_spec.MethodsPower.OnSectorProveCommit, ser, opts...), nil
+func (mp *MessageProducer) PowerOnSectorProveCommit(to, from address.Address, params power.OnSectorProveCommitParams, opts ...MsgOpt) *Message {
+	ser := state.MustSerialize(&params)
+	return mp.Build(to, from, builtin_spec.MethodsPower.OnSectorProveCommit, ser, opts...)
 }
-
-func (mp *MessageProducer) PowerOnSectorTerminate(to, from address.Address, params power.OnSectorTerminateParams, opts ...MsgOpt) (*Message, error) {
-	ser, err := state.Serialize(&params)
-	if err != nil {
-		return nil, err
-	}
-	return mp.Build(to, from, builtin_spec.MethodsPower.OnSectorTerminate, ser, opts...), nil
+func (mp *MessageProducer) PowerOnSectorTerminate(to, from address.Address, params power.OnSectorTerminateParams, opts ...MsgOpt) *Message {
+	ser := state.MustSerialize(&params)
+	return mp.Build(to, from, builtin_spec.MethodsPower.OnSectorTerminate, ser, opts...)
 }
-
-func (mp *MessageProducer) PowerOnSectorTemporaryFaultEffectiveBegin(to, from address.Address, params power.OnSectorTemporaryFaultEffectiveBeginParams, opts ...MsgOpt) (*Message, error) {
-	ser, err := state.Serialize(&params)
-	if err != nil {
-		return nil, err
-	}
-	return mp.Build(to, from, builtin_spec.MethodsPower.OnSectorTemporaryFaultEffectiveBegin, ser, opts...), nil
+func (mp *MessageProducer) PowerOnSectorTemporaryFaultEffectiveBegin(to, from address.Address, params power.OnSectorTemporaryFaultEffectiveBeginParams, opts ...MsgOpt) *Message {
+	ser := state.MustSerialize(&params)
+	return mp.Build(to, from, builtin_spec.MethodsPower.OnSectorTemporaryFaultEffectiveBegin, ser, opts...)
 }
-
-func (mp *MessageProducer) PowerOnSectorTemporaryFaultEffectiveEnd(to, from address.Address, params power.OnSectorTemporaryFaultEffectiveEndParams, opts ...MsgOpt) (*Message, error) {
-	ser, err := state.Serialize(&params)
-	if err != nil {
-		return nil, err
-	}
-	return mp.Build(to, from, builtin_spec.MethodsPower.OnSectorTemporaryFaultEffectiveEnd, ser, opts...), nil
+func (mp *MessageProducer) PowerOnSectorTemporaryFaultEffectiveEnd(to, from address.Address, params power.OnSectorTemporaryFaultEffectiveEndParams, opts ...MsgOpt) *Message {
+	ser := state.MustSerialize(&params)
+	return mp.Build(to, from, builtin_spec.MethodsPower.OnSectorTemporaryFaultEffectiveEnd, ser, opts...)
 }
-
-func (mp *MessageProducer) PowerOnSectorModifyWeightDesc(to, from address.Address, params power.OnSectorModifyWeightDescParams, opts ...MsgOpt) (*Message, error) {
-	ser, err := state.Serialize(&params)
-	if err != nil {
-		return nil, err
-	}
-	return mp.Build(to, from, builtin_spec.MethodsPower.OnSectorModifyWeightDesc, ser, opts...), nil
+func (mp *MessageProducer) PowerOnSectorModifyWeightDesc(to, from address.Address, params power.OnSectorModifyWeightDescParams, opts ...MsgOpt) *Message {
+	ser := state.MustSerialize(&params)
+	return mp.Build(to, from, builtin_spec.MethodsPower.OnSectorModifyWeightDesc, ser, opts...)
 }
-
-func (mp *MessageProducer) PowerOnMinerSurprisePoStSuccess(to, from address.Address, params adt.EmptyValue, opts ...MsgOpt) (*Message, error) {
-	ser, err := state.Serialize(&params)
-	if err != nil {
-		return nil, err
-	}
-	return mp.Build(to, from, builtin_spec.MethodsPower.OnMinerSurprisePoStSuccess, ser, opts...), nil
+func (mp *MessageProducer) PowerOnMinerSurprisePoStSuccess(to, from address.Address, params adt.EmptyValue, opts ...MsgOpt) *Message {
+	ser := state.MustSerialize(&params)
+	return mp.Build(to, from, builtin_spec.MethodsPower.OnMinerSurprisePoStSuccess, ser, opts...)
 }
-
-func (mp *MessageProducer) PowerOnMinerSurprisePoStFailure(to, from address.Address, params power.OnMinerSurprisePoStFailureParams, opts ...MsgOpt) (*Message, error) {
-	ser, err := state.Serialize(&params)
-	if err != nil {
-		return nil, err
-	}
-	return mp.Build(to, from, builtin_spec.MethodsPower.OnMinerSurprisePoStFailure, ser, opts...), nil
+func (mp *MessageProducer) PowerOnMinerSurprisePoStFailure(to, from address.Address, params power.OnMinerSurprisePoStFailureParams, opts ...MsgOpt) *Message {
+	ser := state.MustSerialize(&params)
+	return mp.Build(to, from, builtin_spec.MethodsPower.OnMinerSurprisePoStFailure, ser, opts...)
 }
-
-func (mp *MessageProducer) PowerEnrollCronEvent(to, from address.Address, params power.EnrollCronEventParams, opts ...MsgOpt) (*Message, error) {
-	ser, err := state.Serialize(&params)
-	if err != nil {
-		return nil, err
-	}
-	return mp.Build(to, from, builtin_spec.MethodsPower.EnrollCronEvent, ser, opts...), nil
+func (mp *MessageProducer) PowerEnrollCronEvent(to, from address.Address, params power.EnrollCronEventParams, opts ...MsgOpt) *Message {
+	ser := state.MustSerialize(&params)
+	return mp.Build(to, from, builtin_spec.MethodsPower.EnrollCronEvent, ser, opts...)
 }
-
-func (mp *MessageProducer) PowerReportConsensusFault(to, from address.Address, params power.ReportConsensusFaultParams, opts ...MsgOpt) (*Message, error) {
-	ser, err := state.Serialize(&params)
-	if err != nil {
-		return nil, err
-	}
-	return mp.Build(to, from, builtin_spec.MethodsPower.ReportConsensusFault, ser, opts...), nil
+func (mp *MessageProducer) PowerReportConsensusFault(to, from address.Address, params power.ReportConsensusFaultParams, opts ...MsgOpt) *Message {
+	ser := state.MustSerialize(&params)
+	return mp.Build(to, from, builtin_spec.MethodsPower.ReportConsensusFault, ser, opts...)
 }
-
-func (mp *MessageProducer) PowerOnEpochTickEnd(to, from address.Address, params adt.EmptyValue, opts ...MsgOpt) (*Message, error) {
-	ser, err := state.Serialize(&params)
-	if err != nil {
-		return nil, err
-	}
-	return mp.Build(to, from, builtin_spec.MethodsPower.OnEpochTickEnd, ser, opts...), nil
+func (mp *MessageProducer) PowerOnEpochTickEnd(to, from address.Address, params adt.EmptyValue, opts ...MsgOpt) *Message {
+	ser := state.MustSerialize(&params)
+	return mp.Build(to, from, builtin_spec.MethodsPower.OnEpochTickEnd, ser, opts...)
 }

--- a/pkg/chain/reward.go
+++ b/pkg/chain/reward.go
@@ -9,26 +9,15 @@ import (
 	"github.com/filecoin-project/chain-validation/pkg/state"
 )
 
-func (mp *MessageProducer) RewardConstructor(to, from address.Address, params adt.EmptyValue, opts ...MsgOpt) (*Message, error) {
-	ser, err := state.Serialize(&params)
-	if err != nil {
-		return nil, err
-	}
-	return mp.Build(to, from, builtin_spec.MethodsReward.Constructor, ser, opts...), nil
+func (mp *MessageProducer) RewardConstructor(to, from address.Address, params adt.EmptyValue, opts ...MsgOpt) *Message {
+	ser := state.MustSerialize(&params)
+	return mp.Build(to, from, builtin_spec.MethodsReward.Constructor, ser, opts...)
 }
-
-func (mp *MessageProducer) RewardAwardBlockReward(to, from address.Address, params reward.AwardBlockRewardParams, opts ...MsgOpt) (*Message, error) {
-	ser, err := state.Serialize(&params)
-	if err != nil {
-		return nil, err
-	}
-	return mp.Build(to, from, builtin_spec.MethodsReward.AwardBlockReward, ser, opts...), nil
+func (mp *MessageProducer) RewardAwardBlockReward(to, from address.Address, params reward.AwardBlockRewardParams, opts ...MsgOpt) *Message {
+	ser := state.MustSerialize(&params)
+	return mp.Build(to, from, builtin_spec.MethodsReward.AwardBlockReward, ser, opts...)
 }
-
-func (mp *MessageProducer) RewardWithdrawReward(to, from address.Address, params adt.EmptyValue, opts ...MsgOpt) (*Message, error) {
-	ser, err := state.Serialize(&params)
-	if err != nil {
-		return nil, err
-	}
-	return mp.Build(to, from, builtin_spec.MethodsReward.WithdrawReward, ser, opts...), nil
+func (mp *MessageProducer) RewardWithdrawReward(to, from address.Address, params adt.EmptyValue, opts ...MsgOpt) *Message {
+	ser := state.MustSerialize(&params)
+	return mp.Build(to, from, builtin_spec.MethodsReward.WithdrawReward, ser, opts...)
 }

--- a/pkg/state/serialization.go
+++ b/pkg/state/serialization.go
@@ -7,6 +7,14 @@ import (
 	cbg "github.com/whyrusleeping/cbor-gen"
 )
 
+func MustSerialize(i cbg.CBORMarshaler) []byte {
+	out, err := Serialize(i)
+	if err != nil {
+		panic(err)
+	}
+	return out
+}
+
 func Serialize(i cbg.CBORMarshaler) ([]byte, error) {
 	buf := new(bytes.Buffer)
 	if err := i.MarshalCBOR(buf); err != nil {

--- a/pkg/suites/testdriver.go
+++ b/pkg/suites/testdriver.go
@@ -134,10 +134,7 @@ type TestDriver struct {
 }
 
 // TODO for failure cases we should consider catching panics here else they appear in the test output and obfuscate successful tests.
-func (td *TestDriver) ApplyMessageExpectReceipt(msgF func() (*chain.Message, error), receipt chain.MessageReceipt) {
-	msg, err := msgF()
-	require.NoError(td.T, err)
-
+func (td *TestDriver) ApplyMessageExpectReceipt(msg *chain.Message, receipt chain.MessageReceipt) {
 	msgReceipt, err := td.Validator.ApplyMessage(td.ExeCtx, td.Driver.st, msg)
 	require.NoError(td.T, err)
 
@@ -151,11 +148,10 @@ func (td *TestDriver) MustCreateAndVerifyMultisigActor(nonce int64, value abi_sp
 	multiSigConstuctParams, err := state.Serialize(params)
 	require.NoError(td.T, err)
 
-	msg, err := td.Producer.InitExec(builtin_spec.InitActorAddr, from, init_spec.ExecParams{
+	msg := td.Producer.InitExec(builtin_spec.InitActorAddr, from, init_spec.ExecParams{
 		CodeCID:           builtin_spec.MultisigActorCodeID,
 		ConstructorParams: multiSigConstuctParams,
 	}, chain.Value(value), chain.Nonce(nonce))
-	require.NoError(td.T, err)
 
 	msgReceipt, err := td.Validator.ApplyMessage(td.ExeCtx, td.Driver.State(), msg)
 	require.NoError(td.T, err)
@@ -182,8 +178,7 @@ func (td *TestDriver) MustCreateAndVerifyMultisigActor(nonce int64, value abi_sp
 
 func (td *TestDriver) MustProposeMultisigTransfer(nonce int64, value abi_spec.TokenAmount, txID multisig_spec.TxnID, multisigAddr, from address.Address, params multisig_spec.ProposeParams, receipt chain.MessageReceipt) {
 	/* Propose the transactions */
-	msg, err := td.Producer.MultisigPropose(multisigAddr, from, params, chain.Value(value), chain.Nonce(nonce))
-	require.NoError(td.T, err)
+	msg := td.Producer.MultisigPropose(multisigAddr, from, params, chain.Value(value), chain.Nonce(nonce))
 	msgReceipt, err := td.Validator.ApplyMessage(td.ExeCtx, td.Driver.State(), msg)
 	require.NoError(td.T, err)
 
@@ -192,8 +187,7 @@ func (td *TestDriver) MustProposeMultisigTransfer(nonce int64, value abi_spec.To
 }
 
 func (td *TestDriver) MustApproveMultisigActor(nonce int64, value abi_spec.TokenAmount, ms, from address.Address, txID multisig_spec.TxnID, receipt chain.MessageReceipt) {
-	msg, err := td.Producer.MultisigApprove(ms, from, multisig_spec.TxnIDParams{ID: txID}, chain.Value(value), chain.Nonce(nonce))
-	require.NoError(td.T, err)
+	msg := td.Producer.MultisigApprove(ms, from, multisig_spec.TxnIDParams{ID: txID}, chain.Value(value), chain.Nonce(nonce))
 
 	msgReceipt, err := td.Validator.ApplyMessage(td.ExeCtx, td.Driver.State(), msg)
 	require.NoError(td.T, err)
@@ -202,8 +196,7 @@ func (td *TestDriver) MustApproveMultisigActor(nonce int64, value abi_spec.Token
 }
 
 func (td *TestDriver) MustCancelMultisigActor(nonce int64, value abi_spec.TokenAmount, ms, from address.Address, txID multisig_spec.TxnID, receipt chain.MessageReceipt) {
-	msg, err := td.Producer.MultisigCancel(ms, from, multisig_spec.TxnIDParams{ID: txID}, chain.Value(value), chain.Nonce(nonce))
-	require.NoError(td.T, err)
+	msg := td.Producer.MultisigCancel(ms, from, multisig_spec.TxnIDParams{ID: txID}, chain.Value(value), chain.Nonce(nonce))
 
 	msgReceipt, err := td.Validator.ApplyMessage(td.ExeCtx, td.Driver.State(), msg)
 	require.NoError(td.T, err)


### PR DESCRIPTION
Motivation: Errors only existed since serialization of message parameters could fail. Tests are cleaner if they don't need to check serialization failures, so panic for the case that seralizating message params fails.