### PR TITLE
add basic paych tests

### DIFF
--- a/chain/sugar.go
+++ b/chain/sugar.go
@@ -3,6 +3,8 @@ package chain
 import (
 	"github.com/filecoin-project/go-address"
 	builtin_spec "github.com/filecoin-project/specs-actors/actors/builtin"
+	init_spec "github.com/filecoin-project/specs-actors/actors/builtin/init"
+	paych_spec "github.com/filecoin-project/specs-actors/actors/builtin/paych"
 
 	"github.com/filecoin-project/chain-validation/chain/types"
 )
@@ -12,4 +14,14 @@ var noParams []byte
 // Transfer builds a simple value transfer message and returns it.
 func (mp *MessageProducer) Transfer(to, from address.Address, opts ...MsgOpt) *types.Message {
 	return mp.Build(to, from, builtin_spec.MethodSend, noParams, opts...)
+}
+
+func (mp *MessageProducer) CreatePaymentChannel(to, from address.Address, opts ...MsgOpt) *types.Message {
+	return mp.InitExec(builtin_spec.InitActorAddr, from, init_spec.ExecParams{
+		CodeCID: builtin_spec.PaymentChannelActorCodeID,
+		ConstructorParams: MustSerialize(&paych_spec.ConstructorParams{
+			From: from,
+			To:   to,
+		}),
+	}, opts...)
 }

--- a/drivers/state.go
+++ b/drivers/state.go
@@ -1,11 +1,14 @@
 package drivers
 
 import (
+	"context"
 	"testing"
 
 	"github.com/filecoin-project/go-address"
 	abi_spec "github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/ipfs/go-cid"
 	"github.com/stretchr/testify/require"
+	cbg "github.com/whyrusleeping/cbor-gen"
 
 	builtin_spec "github.com/filecoin-project/specs-actors/actors/builtin"
 
@@ -31,6 +34,22 @@ func NewStateDriver(tb testing.TB, w state.Wrapper) *StateDriver {
 // State returns the state.
 func (d *StateDriver) State() state.Wrapper {
 	return d.st
+}
+
+func (d *StateDriver) GetState(c cid.Cid, out cbg.CBORUnmarshaler) {
+	strg, err := d.st.Storage()
+	require.NoError(d.tb, err)
+
+	err = strg.Get(context.Background(), c, out)
+	require.NoError(d.tb, err)
+}
+
+func (d *StateDriver) GetActorState(actorAddr address.Address, out cbg.CBORUnmarshaler) {
+	actor, err := d.State().Actor(actorAddr)
+	require.NoError(d.tb, err)
+	require.NotNil(d.tb, actor)
+
+	d.GetState(actor.Head(), out)
 }
 
 // NewAccountActor installs a new account actor, returning the address.

--- a/suites/paych.go
+++ b/suites/paych.go
@@ -1,0 +1,103 @@
+package suites
+
+import (
+	"context"
+	"testing"
+
+	"github.com/filecoin-project/go-address"
+	abi_spec "github.com/filecoin-project/specs-actors/actors/abi"
+	big_spec "github.com/filecoin-project/specs-actors/actors/abi/big"
+	builtin_spec "github.com/filecoin-project/specs-actors/actors/builtin"
+	paych_spec "github.com/filecoin-project/specs-actors/actors/builtin/paych"
+	crypto_spec "github.com/filecoin-project/specs-actors/actors/crypto"
+	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/filecoin-project/chain-validation/chain"
+	"github.com/filecoin-project/chain-validation/chain/types"
+	"github.com/filecoin-project/chain-validation/drivers"
+	"github.com/filecoin-project/chain-validation/state"
+	"github.com/filecoin-project/chain-validation/suites/utils"
+)
+
+func TestPaych(t *testing.T, factory state.Factories) {
+	defaultMiner := utils.NewSECP256K1Addr(t, "miner")
+
+	builder := drivers.NewBuilder(context.Background(), factory).
+		WithDefaultGasLimit(big_spec.NewInt(1000000)).
+		WithDefaultGasPrice(big_spec.NewInt(1)).
+		WithSingletonActors(map[address.Address]big_spec.Int{
+			builtin_spec.InitActorAddr:         big_spec.NewInt(0),
+			builtin_spec.BurntFundsActorAddr:   big_spec.NewInt(0),
+			builtin_spec.StoragePowerActorAddr: big_spec.NewInt(0),
+			builtin_spec.RewardActorAddr:       TotalNetworkBalance,
+		}).
+		WithDefaultMiner(defaultMiner)
+
+	var initialBal = abi_spec.NewTokenAmount(200_000_000_000)
+	toSend := abi_spec.NewTokenAmount(10_000)
+	t.Run("happy path constructor", func(t *testing.T) {
+		td := builder.Build(t)
+
+		// will create and send on payment channel
+		sender := td.NewAccountActor(drivers.SECP, initialBal) // 101
+		// will be receiver on paych
+		receiver := td.NewAccountActor(drivers.SECP, initialBal) // 102
+		// the _expected_ address of the payment channel
+		paychAddr := utils.NewIDAddr(t, 103) // 103
+
+		// init actor creates the payment channel
+		td.ApplyMessageExpectReceipt(
+			td.Producer.CreatePaymentChannel(sender, receiver, chain.Value(toSend), chain.Nonce(0)),
+			types.MessageReceipt{ExitCode: 0, ReturnValue: paychAddr.Bytes(), GasUsed: big_spec.Zero()},
+		)
+
+		var pcState paych_spec.State
+		td.GetActorState(paychAddr, &pcState)
+		assert.Equal(t, sender, pcState.To)
+		assert.Equal(t, receiver, pcState.From)
+		assert.Equal(t, toSend, pcState.ToSend)
+	})
+
+	t.Run("happy path update", func(t *testing.T) {
+		td := builder.Build(t)
+
+		const pcTimeLock = abi_spec.ChainEpoch(10)
+		const pcLane = int64(123)
+		const pcNonce = int64(1)
+		var pcAmount = big_spec.NewInt(10)
+		var pcSig = &crypto_spec.Signature{
+			Type: crypto_spec.SigTypeBLS,
+			Data: []byte("does this matter??!!"),
+		}
+
+		// create the payment channel
+		sender := td.NewAccountActor(drivers.SECP, initialBal)   // 101
+		receiver := td.NewAccountActor(drivers.SECP, initialBal) // 102
+		paychAddr := utils.NewIDAddr(t, 103)                     // 103
+		td.ApplyMessageExpectReceipt(
+			td.Producer.CreatePaymentChannel(sender, receiver, chain.Value(toSend), chain.Nonce(0)),
+			types.MessageReceipt{ExitCode: 0, ReturnValue: paychAddr.Bytes(), GasUsed: big_spec.Zero()},
+		)
+
+		td.ApplyMessageExpectReceipt(
+			td.Producer.PaychUpdateChannelState(paychAddr, sender, paych_spec.UpdateChannelStateParams{
+				Sv: paych_spec.SignedVoucher{
+					TimeLock:  pcTimeLock,
+					Lane:      pcLane,
+					Nonce:     pcNonce,
+					Amount:    pcAmount,
+					Signature: pcSig,
+				},
+			}, chain.Nonce(1), chain.Value(big_spec.Zero())),
+			types.MessageReceipt{ExitCode: exitcode.Ok, ReturnValue: nil, GasUsed: big_spec.Zero()},
+		)
+		var pcState paych_spec.State
+		td.GetActorState(paychAddr, &pcState)
+		assert.Equal(t, 1, len(pcState.LaneStates))
+		ls := pcState.LaneStates[0]
+		assert.Equal(t, pcAmount, ls.Redeemed)
+		assert.Equal(t, pcNonce, ls.Nonce)
+		assert.Equal(t, pcLane, ls.ID)
+	})
+}

--- a/suites/utils/address.go
+++ b/suites/utils/address.go
@@ -1,0 +1,46 @@
+package utils
+
+import (
+	"math/rand"
+	"testing"
+
+	addr "github.com/filecoin-project/go-address"
+)
+
+func NewIDAddr(t *testing.T, id uint64) addr.Address {
+	address, err := addr.NewIDAddress(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return address
+}
+
+func NewSECP256K1Addr(t *testing.T, pubkey string) addr.Address {
+	// the pubkey of a secp256k1 address is hashed for consistent length.
+	address, err := addr.NewSecp256k1Address([]byte(pubkey))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return address
+}
+
+func NewBLSAddr(t *testing.T, seed int64) addr.Address {
+	// the pubkey of a bls address is not hashed and must be the correct length.
+	buf := make([]byte, 48)
+	r := rand.New(rand.NewSource(seed))
+	r.Read(buf)
+
+	address, err := addr.NewBLSAddress(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return address
+}
+
+func NewActorAddr(t *testing.T, data string) addr.Address {
+	address, err := addr.NewActorAddress([]byte(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return address
+}


### PR DESCRIPTION
This PR Adds:
- 3 payment channel tests - construct, update and collect
- sugar method for creating a payment channel
- address helper methods for creating addresses without returning errors. 