### PR TITLE
correctly computer the init actor return value

### DIFF
--- a/suites/create_actor.go
+++ b/suites/create_actor.go
@@ -157,18 +157,25 @@ func TestInitActorSequentialIDAddressCreate(t *testing.T, factory state.Factorie
 	var initialBal = abi_spec.NewTokenAmount(200_000_000_000)
 	var toSend = abi_spec.NewTokenAmount(10_000)
 
-	sender := td.NewAccountActor(drivers.SECP, initialBal)   // 101
-	receiver := td.NewAccountActor(drivers.SECP, initialBal) // 102
-	firstPaychAddr := utils.NewIDAddr(t, 103)                // 103
-	secondPaychAddr := utils.NewIDAddr(t, 104)               // 104
+	sender := td.NewAccountActor(drivers.SECP, initialBal)
+	senderID := utils.NewIDAddr(t, 100)
+
+	receiver := td.NewAccountActor(drivers.SECP, initialBal)
+
+	firstPaychAddr := utils.NewIDAddr(t, 102)
+	secondPaychAddr := utils.NewIDAddr(t, 103)
+
+	firstInitRet := td.ComputeInitActorExecReturn(senderID, 0, firstPaychAddr)
+	secondInitRet := td.ComputeInitActorExecReturn(senderID, 1, secondPaychAddr)
 
 	td.ApplyMessageExpectReceipt(
-		td.Producer.CreatePaymentChannelActor(sender, receiver, chain.Value(toSend), chain.Nonce(0)),
-		types.MessageReceipt{ExitCode: exitcode_spec.Ok, ReturnValue: firstPaychAddr.Bytes(), GasUsed: big_spec.Zero()},
+		td.Producer.CreatePaymentChannelActor(receiver, sender, chain.Value(toSend), chain.Nonce(0)),
+		types.MessageReceipt{ExitCode: exitcode_spec.Ok, ReturnValue: chain.MustSerialize(&firstInitRet), GasUsed: big_spec.Zero()},
 	)
 
 	td.ApplyMessageExpectReceipt(
-		td.Producer.CreatePaymentChannelActor(sender, receiver, chain.Value(toSend), chain.Nonce(1)),
-		types.MessageReceipt{ExitCode: exitcode_spec.Ok, ReturnValue: secondPaychAddr.Bytes(), GasUsed: big_spec.Zero()},
+		td.Producer.CreatePaymentChannelActor(receiver, sender, chain.Value(toSend), chain.Nonce(1)),
+		types.MessageReceipt{ExitCode: exitcode_spec.Ok, ReturnValue: chain.MustSerialize(&secondInitRet), GasUsed: big_spec.Zero()},
 	)
+
 }

--- a/suites/multisig.go
+++ b/suites/multisig.go
@@ -14,7 +14,7 @@ import (
 	reward_spec "github.com/filecoin-project/specs-actors/actors/builtin/reward"
 	exitcode_spec "github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
 
-	chain "github.com/filecoin-project/chain-validation/chain"
+	"github.com/filecoin-project/chain-validation/chain"
 	"github.com/filecoin-project/chain-validation/chain/types"
 	"github.com/filecoin-project/chain-validation/drivers"
 	"github.com/filecoin-project/chain-validation/state"
@@ -59,10 +59,12 @@ func TestMultiSigActor(t *testing.T, factory state.Factories) {
 
 		// creator of the multisig actor
 		alice := td.NewAccountActor(drivers.SECP, initialBal)
+		aliceId := utils.NewIDAddr(t, 100)
 
 		// expected address of the actor
-		multisigAddr := utils.NewIDAddr(t, 102)
+		multisigAddr := utils.NewIDAddr(t, 101)
 
+		createRet := td.ComputeInitActorExecReturn(aliceId, 0, multisigAddr)
 		td.MustCreateAndVerifyMultisigActor(0, valueSend, multisigAddr, alice,
 			&multisig_spec.ConstructorParams{
 				Signers:               []address.Address{alice},
@@ -71,7 +73,7 @@ func TestMultiSigActor(t *testing.T, factory state.Factories) {
 			},
 			types.MessageReceipt{
 				ExitCode:    exitcode_spec.Ok,
-				ReturnValue: multisigAddr.Bytes(),
+				ReturnValue: chain.MustSerialize(&createRet),
 				GasUsed:     big_spec.NewInt(1125),
 			})
 	})
@@ -85,11 +87,14 @@ func TestMultiSigActor(t *testing.T, factory state.Factories) {
 		td := builder.Build(t)
 
 		alice := td.NewAccountActor(drivers.SECP, initialBal)
+		aliceId := utils.NewIDAddr(t, 100)
+
 		bob := td.NewAccountActor(drivers.SECP, initialBal)
 		outsider := td.NewAccountActor(drivers.SECP, initialBal)
 
-		multisigAddr := utils.NewIDAddr(t, 104)
+		multisigAddr := utils.NewIDAddr(t, 103)
 
+		createRet := td.ComputeInitActorExecReturn(aliceId, 0, multisigAddr)
 		// create the multisig actor
 		td.MustCreateAndVerifyMultisigActor(0, valueSend, multisigAddr, alice,
 			&multisig_spec.ConstructorParams{
@@ -99,7 +104,7 @@ func TestMultiSigActor(t *testing.T, factory state.Factories) {
 			},
 			types.MessageReceipt{
 				ExitCode:    exitcode_spec.Ok,
-				ReturnValue: multisigAddr.Bytes(),
+				ReturnValue: chain.MustSerialize(&createRet),
 				GasUsed:     big_spec.NewInt(1387),
 			})
 		td.AssertBalance(multisigAddr, valueSend)
@@ -484,5 +489,4 @@ func TestMultiSigActor(t *testing.T, factory state.Factories) {
 			UnlockDuration:        unlockDuration,
 		})
 	})
-
 }


### PR DESCRIPTION
Tests were not correctly computing the init actors exec return value. Add `ComputeInitActorExecReturn` method to test driver that correctly computes it. 