### PR TITLE
test driver creates a miner actor in the state tree

### DIFF
--- a/suites/create_actor.go
+++ b/suites/create_actor.go
@@ -25,6 +25,7 @@ func TestAccountActorCreation(t *testing.T, factory state.Factories) {
 			drivers.DefaultInitActorState,
 			drivers.DefaultRewardActorState,
 			drivers.DefaultBurntFundsActorState,
+			drivers.DefaultStoragePowerActorState,
 		})
 
 	testCases := []struct {
@@ -112,6 +113,7 @@ func TestInitActorSequentialIDAddressCreate(t *testing.T, factory state.Factorie
 			drivers.DefaultInitActorState,
 			drivers.DefaultRewardActorState,
 			drivers.DefaultBurntFundsActorState,
+			drivers.DefaultStoragePowerActorState,
 		}).Build(t)
 
 	var initialBal = abi_spec.NewTokenAmount(200_000_000_000)
@@ -119,10 +121,10 @@ func TestInitActorSequentialIDAddressCreate(t *testing.T, factory state.Factorie
 
 	sender, senderID := td.NewAccountActor(drivers.SECP, initialBal)
 
-	receiver, _ := td.NewAccountActor(drivers.SECP, initialBal)
+	receiver, receiverID := td.NewAccountActor(drivers.SECP, initialBal)
 
-	firstPaychAddr := utils.NewIDAddr(t, 102)
-	secondPaychAddr := utils.NewIDAddr(t, 103)
+	firstPaychAddr := utils.NewIDAddr(t, utils.IdFromAddress(receiverID)+1)
+	secondPaychAddr := utils.NewIDAddr(t, utils.IdFromAddress(receiverID)+2)
 
 	firstInitRet := td.ComputeInitActorExecReturn(senderID, 0, firstPaychAddr)
 	secondInitRet := td.ComputeInitActorExecReturn(senderID, 1, secondPaychAddr)

--- a/suites/message_application.go
+++ b/suites/message_application.go
@@ -27,6 +27,7 @@ func TestMessageApplicationEdgecases(t *testing.T, factory state.Factories) {
 			drivers.DefaultInitActorState,
 			drivers.DefaultRewardActorState,
 			drivers.DefaultBurntFundsActorState,
+			drivers.DefaultStoragePowerActorState,
 		})
 
 	var aliceBal = abi_spec.NewTokenAmount(1_000_000_000)
@@ -95,12 +96,12 @@ func TestMessageApplicationEdgecases(t *testing.T, factory state.Factories) {
 		}
 
 		// will create and send on payment channel
-		sender, senderID := td.NewAccountActor(drivers.SECP, initialBal) // 100
+		sender, senderID := td.NewAccountActor(drivers.SECP, initialBal)
 		// will be receiver on paych
-		receiver, _ := td.NewAccountActor(drivers.SECP, initialBal) // 101
+		receiver, receiverID := td.NewAccountActor(drivers.SECP, initialBal)
 
 		// the _expected_ address of the payment channel
-		paychAddr := utils.NewIDAddr(t, 102) // 103
+		paychAddr := utils.NewIDAddr(t, utils.IdFromAddress(receiverID)+1)
 		createRet := td.ComputeInitActorExecReturn(senderID, 0, paychAddr)
 		td.ApplyMessageExpectReceipt(
 			td.MessageProducer.CreatePaymentChannelActor(receiver, sender, chain.Value(toSend), chain.Nonce(0)),

--- a/suites/tipset_application.go
+++ b/suites/tipset_application.go
@@ -10,7 +10,6 @@ import (
 	builtin_spec "github.com/filecoin-project/specs-actors/actors/builtin"
 	"github.com/filecoin-project/specs-actors/actors/crypto"
 	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
-	"github.com/multiformats/go-varint"
 	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/chain-validation/chain"
@@ -32,7 +31,7 @@ func TestBlockMessageInfoApplication(t *testing.T, factory state.Factories) {
 		// creat a miner, owner, and its worker
 		minerOwner, _ := td.NewAccountActor(address.SECP256K1, big_spec.NewInt(1_000_000_000))
 		minerWorker, minerWorkerID := td.NewAccountActor(address.BLS, big_spec.Zero())
-		expectedRet := td.ComputeInitActorExecReturn(builtin_spec.StoragePowerActorAddr, 0, utils.NewIDAddr(t, idFromAddress(minerWorkerID)+1))
+		expectedRet := td.ComputeInitActorExecReturn(builtin_spec.StoragePowerActorAddr, 0, utils.NewIDAddr(t, utils.IdFromAddress(minerWorkerID)+1))
 		td.ApplyMessageExpectReceipt(
 			td.MessageProducer.CreateMinerActor(minerOwner, minerWorker, abi_spec.SectorSize(1), "peerId", chain.Nonce(0), chain.Value(big_spec.NewInt(1_000_000))),
 			types.MessageReceipt{ExitCode: exitcode.Ok, ReturnValue: chain.MustSerialize(&expectedRet), GasUsed: big_spec.Zero()},
@@ -64,7 +63,7 @@ func TestBlockMessageInfoApplication(t *testing.T, factory state.Factories) {
 		// creat a miner, owner, and its worker
 		minerOwner, _ := td.NewAccountActor(address.SECP256K1, big_spec.NewInt(1_000_000_000))
 		minerWorker, minerWorkerID := td.NewAccountActor(address.BLS, big_spec.Zero())
-		expectedRet := td.ComputeInitActorExecReturn(builtin_spec.StoragePowerActorAddr, 0, utils.NewIDAddr(t, idFromAddress(minerWorkerID)+1))
+		expectedRet := td.ComputeInitActorExecReturn(builtin_spec.StoragePowerActorAddr, 0, utils.NewIDAddr(t, utils.IdFromAddress(minerWorkerID)+1))
 		td.ApplyMessageExpectReceipt(
 			td.MessageProducer.CreateMinerActor(minerOwner, minerWorker, abi_spec.SectorSize(1), "peerId", chain.Nonce(0), chain.Value(big_spec.NewInt(1_000_000))),
 			types.MessageReceipt{ExitCode: exitcode.Ok, ReturnValue: chain.MustSerialize(&expectedRet), GasUsed: big_spec.Zero()},
@@ -98,7 +97,7 @@ func TestBlockMessageInfoApplication(t *testing.T, factory state.Factories) {
 		// creat a miner, owner, and its worker
 		minerOwner, _ := td.NewAccountActor(address.SECP256K1, big_spec.NewInt(1_000_000_000))
 		minerWorker, minerWorkerID := td.NewAccountActor(address.BLS, big_spec.Zero())
-		expectedRet := td.ComputeInitActorExecReturn(builtin_spec.StoragePowerActorAddr, 0, utils.NewIDAddr(t, idFromAddress(minerWorkerID)+1))
+		expectedRet := td.ComputeInitActorExecReturn(builtin_spec.StoragePowerActorAddr, 0, utils.NewIDAddr(t, utils.IdFromAddress(minerWorkerID)+1))
 		td.ApplyMessageExpectReceipt(
 			td.MessageProducer.CreateMinerActor(minerOwner, minerWorker, abi_spec.SectorSize(1), "peerId", chain.Nonce(0), chain.Value(big_spec.NewInt(1_000_000))),
 			types.MessageReceipt{ExitCode: exitcode.Ok, ReturnValue: chain.MustSerialize(&expectedRet), GasUsed: big_spec.Zero()},
@@ -130,7 +129,7 @@ func TestBlockMessageInfoApplication(t *testing.T, factory state.Factories) {
 		// creat a miner, owner, and its worker
 		minerOwner, _ := td.NewAccountActor(address.SECP256K1, big_spec.NewInt(1_000_000_000))
 		minerWorker, minerWorkerID := td.NewAccountActor(address.BLS, big_spec.Zero())
-		expectedRet := td.ComputeInitActorExecReturn(builtin_spec.StoragePowerActorAddr, 0, utils.NewIDAddr(t, idFromAddress(minerWorkerID)+1))
+		expectedRet := td.ComputeInitActorExecReturn(builtin_spec.StoragePowerActorAddr, 0, utils.NewIDAddr(t, utils.IdFromAddress(minerWorkerID)+1))
 		td.ApplyMessageExpectReceipt(
 			td.MessageProducer.CreateMinerActor(minerOwner, minerWorker, abi_spec.SectorSize(1), "peerId", chain.Nonce(0), chain.Value(big_spec.NewInt(1_000_000))),
 			types.MessageReceipt{ExitCode: exitcode.Ok, ReturnValue: chain.MustSerialize(&expectedRet), GasUsed: big_spec.Zero()},
@@ -163,7 +162,7 @@ func TestBlockMessageInfoApplication(t *testing.T, factory state.Factories) {
 		// creat a miner, owner, and its worker
 		minerOwner, _ := td.NewAccountActor(address.SECP256K1, big_spec.NewInt(1_000_000_000))
 		minerWorker, minerWorkerID := td.NewAccountActor(address.BLS, big_spec.Zero())
-		expectedRet := td.ComputeInitActorExecReturn(builtin_spec.StoragePowerActorAddr, 0, utils.NewIDAddr(t, idFromAddress(minerWorkerID)+1))
+		expectedRet := td.ComputeInitActorExecReturn(builtin_spec.StoragePowerActorAddr, 0, utils.NewIDAddr(t, utils.IdFromAddress(minerWorkerID)+1))
 		td.ApplyMessageExpectReceipt(
 			td.MessageProducer.CreateMinerActor(minerOwner, minerWorker, abi_spec.SectorSize(1), "peerId", chain.Nonce(0), chain.Value(big_spec.NewInt(1_000_000))),
 			types.MessageReceipt{ExitCode: exitcode.Ok, ReturnValue: chain.MustSerialize(&expectedRet), GasUsed: big_spec.Zero()},
@@ -190,17 +189,6 @@ func TestBlockMessageInfoApplication(t *testing.T, factory state.Factories) {
 		td.AssertBalance(receiver, big_spec.NewInt(100))
 	})
 
-}
-
-func idFromAddress(a address.Address) uint64 {
-	if a.Protocol() != address.ID {
-		panic("must be ID protocol address")
-	}
-	id, _, err := varint.FromUvarint(a.Payload())
-	if err != nil {
-		panic(err)
-	}
-	return id
 }
 
 // TODO produce a valid signature

--- a/suites/transfer.go
+++ b/suites/transfer.go
@@ -45,6 +45,7 @@ func TestValueTransferSimple(t *testing.T, factories state.Factories) {
 			drivers.DefaultInitActorState,
 			drivers.DefaultRewardActorState,
 			drivers.DefaultBurntFundsActorState,
+			drivers.DefaultStoragePowerActorState,
 		})
 
 	testCases := []valueTransferTestCases{
@@ -165,6 +166,7 @@ func TestValueTransferAdvance(t *testing.T, factory state.Factories) {
 			drivers.DefaultInitActorState,
 			drivers.DefaultRewardActorState,
 			drivers.DefaultBurntFundsActorState,
+			drivers.DefaultStoragePowerActorState,
 		})
 
 	t.Run("self transfer", func(t *testing.T) {

--- a/suites/utils/address.go
+++ b/suites/utils/address.go
@@ -5,8 +5,10 @@ import (
 	"testing"
 
 	addr "github.com/filecoin-project/go-address"
+	"github.com/multiformats/go-varint"
 )
 
+// If you use this method while writing a test you are more than likely doing something wrong.
 func NewIDAddr(t testing.TB, id uint64) addr.Address {
 	address, err := addr.NewIDAddress(id)
 	if err != nil {
@@ -43,4 +45,15 @@ func NewActorAddr(t testing.TB, data string) addr.Address {
 		t.Fatal(err)
 	}
 	return address
+}
+
+func IdFromAddress(a addr.Address) uint64 {
+	if a.Protocol() != addr.ID {
+		panic("must be ID protocol address")
+	}
+	id, _, err := varint.FromUvarint(a.Payload())
+	if err != nil {
+		panic(err)
+	}
+	return id
 }


### PR DESCRIPTION
Build a miner in the state tree automatically as some imples (lotus) requires it exists for message application.