### PR TITLE
return validation tests as a slice

### DIFF
--- a/suites/message/create_actor.go
+++ b/suites/message/create_actor.go
@@ -1,4 +1,4 @@
-package suites
+package message
 
 import (
 	"context"

--- a/suites/message/message_application.go
+++ b/suites/message/message_application.go
@@ -1,4 +1,4 @@
-package suites
+package message
 
 import (
 	"context"

--- a/suites/message/multisig.go
+++ b/suites/message/multisig.go
@@ -1,4 +1,4 @@
-package suites
+package message
 
 import (
 	"context"

--- a/suites/message/paych.go
+++ b/suites/message/paych.go
@@ -1,4 +1,4 @@
-package suites
+package message
 
 import (
 	"context"

--- a/suites/message/transfer.go
+++ b/suites/message/transfer.go
@@ -1,4 +1,4 @@
-package suites
+package message
 
 import (
 	"context"

--- a/suites/tipset/tipset_application.go
+++ b/suites/tipset/tipset_application.go
@@ -1,4 +1,4 @@
-package suites
+package tipset
 
 import (
 	"context"

--- a/suites/validations.go
+++ b/suites/validations.go
@@ -1,0 +1,29 @@
+package suites
+
+import (
+	"testing"
+
+	"github.com/filecoin-project/chain-validation/state"
+	"github.com/filecoin-project/chain-validation/suites/message"
+	"github.com/filecoin-project/chain-validation/suites/tipset"
+)
+
+type TestCase func(t *testing.T, factory state.Factories)
+
+func MessageTestCases() []TestCase {
+	return []TestCase{
+		message.TestAccountActorCreation,
+		message.TestInitActorSequentialIDAddressCreate,
+		message.TestMessageApplicationEdgecases,
+		message.TestMultiSigActor,
+		message.TestPaych,
+		message.TestValueTransferAdvance,
+		message.TestValueTransferSimple,
+	}
+}
+
+func TipSetTestCases() []TestCase {
+	return []TestCase{
+		tipset.TestBlockMessageInfoApplication,
+	}
+}


### PR DESCRIPTION
- implementations can update chain-validation and run all new tests
without updating their test files