### PR TITLE
Make tests spec-compliant and pass on Lotus 

### DIFF
--- a/drivers/state.go
+++ b/drivers/state.go
@@ -95,7 +95,7 @@ func (d *StateDriver) newMinerAccountActor() address.Address {
 	_, minerOwnerID := d.NewAccountActor(address.SECP256K1, big_spec.NewInt(1_000_000_000))
 	_, minerWorkerID := d.NewAccountActor(address.BLS, big_spec.Zero())
 	expectedMinerActorIDAddress := utils.NewIDAddr(d.tb, utils.IdFromAddress(minerWorkerID)+1)
-	minerActorAddrs := computeInitActorExecReturn(d.tb, builtin_spec.StoragePowerActorAddr, 0, expectedMinerActorIDAddress)
+	minerActorAddrs := computeInitActorExecReturn(d.tb, builtin_spec.StoragePowerActorAddr, 0, 1, expectedMinerActorIDAddress)
 
 	// create the miner actor so it exists in the init actors map
 	_, minerActorIDAddr, err := d.State().CreateActor(builtin_spec.StorageMinerActorCodeID, minerActorAddrs.RobustAddress, big_spec.Zero(), &miner_spec.State{

--- a/drivers/test.go
+++ b/drivers/test.go
@@ -338,16 +338,16 @@ func (td *TestDriver) AssertMultisigState(multisigAddr address.Address, expected
 	}
 }
 
-func (td *TestDriver) ComputeInitActorExecReturn(from address.Address, callSeq uint64, expectedNewAddr address.Address) init_spec.ExecReturn {
-	return computeInitActorExecReturn(td.T, from, callSeq, expectedNewAddr)
+func (td *TestDriver) ComputeInitActorExecReturn(from address.Address, callSeq int64, internalCallSeq int64, expectedNewAddr address.Address) init_spec.ExecReturn {
+	return computeInitActorExecReturn(td.T, from, callSeq, internalCallSeq, expectedNewAddr)
 }
 
-func computeInitActorExecReturn(t testing.TB, from address.Address, callSeq uint64, expectedNewAddr address.Address) init_spec.ExecReturn {
+func computeInitActorExecReturn(t testing.TB, from address.Address, callSeq int64, internalCallSeq int64, expectedNewAddr address.Address) init_spec.ExecReturn {
 	buf := new(bytes.Buffer)
 
 	require.NoError(t, from.MarshalCBOR(buf))
 	require.NoError(t, binary.Write(buf, binary.BigEndian, callSeq))
-	require.NoError(t, binary.Write(buf, binary.BigEndian, uint64(0))) // TODO this is wrong, but lotus does it this way
+	require.NoError(t, binary.Write(buf, binary.BigEndian, internalCallSeq))
 
 	out, err := address.NewActorAddress(buf.Bytes())
 	require.NoError(t, err)

--- a/suites/message/create_actor.go
+++ b/suites/message/create_actor.go
@@ -109,15 +109,15 @@ func TestInitActorSequentialIDAddressCreate(t *testing.T, factory state.Factorie
 	var initialBal = abi_spec.NewTokenAmount(200_000_000_000)
 	var toSend = abi_spec.NewTokenAmount(10_000)
 
-	sender, senderID := td.NewAccountActor(drivers.SECP, initialBal)
+	sender, _ := td.NewAccountActor(drivers.SECP, initialBal)
 
 	receiver, receiverID := td.NewAccountActor(drivers.SECP, initialBal)
 
 	firstPaychAddr := utils.NewIDAddr(t, utils.IdFromAddress(receiverID)+1)
 	secondPaychAddr := utils.NewIDAddr(t, utils.IdFromAddress(receiverID)+2)
 
-	firstInitRet := td.ComputeInitActorExecReturn(senderID, 0, firstPaychAddr)
-	secondInitRet := td.ComputeInitActorExecReturn(senderID, 1, secondPaychAddr)
+	firstInitRet := td.ComputeInitActorExecReturn(sender, 0, 0, firstPaychAddr)
+	secondInitRet := td.ComputeInitActorExecReturn(sender, 1, 0, secondPaychAddr)
 
 	td.ApplyMessageExpectReceipt(
 		td.MessageProducer.CreatePaymentChannelActor(receiver, sender, chain.Value(toSend), chain.Nonce(0)),

--- a/suites/message/message_application.go
+++ b/suites/message/message_application.go
@@ -90,13 +90,13 @@ func TestMessageApplicationEdgecases(t *testing.T, factory state.Factories) {
 		}
 
 		// will create and send on payment channel
-		sender, senderID := td.NewAccountActor(drivers.SECP, initialBal)
+		sender, _ := td.NewAccountActor(drivers.SECP, initialBal)
 		// will be receiver on paych
 		receiver, receiverID := td.NewAccountActor(drivers.SECP, initialBal)
 
 		// the _expected_ address of the payment channel
 		paychAddr := utils.NewIDAddr(t, utils.IdFromAddress(receiverID)+1)
-		createRet := td.ComputeInitActorExecReturn(senderID, 0, paychAddr)
+		createRet := td.ComputeInitActorExecReturn(sender, 0, 0, paychAddr)
 		td.ApplyMessageExpectReceipt(
 			td.MessageProducer.CreatePaymentChannelActor(receiver, sender, chain.Value(toSend), chain.Nonce(0)),
 			types.MessageReceipt{ExitCode: exitcode.Ok, ReturnValue: chain.MustSerialize(&createRet), GasUsed: abi_spec.NewTokenAmount(1416)},

--- a/suites/message/multisig.go
+++ b/suites/message/multisig.go
@@ -38,7 +38,7 @@ func TestMultiSigActor(t *testing.T, factory state.Factories) {
 		// expected address of the actor
 		multisigAddr := utils.NewIDAddr(t, 1+utils.IdFromAddress(aliceId))
 
-		createRet := td.ComputeInitActorExecReturn(aliceId, 0, multisigAddr)
+		createRet := td.ComputeInitActorExecReturn(alice, 0, 0, multisigAddr)
 		td.MustCreateAndVerifyMultisigActor(0, valueSend, multisigAddr, alice,
 			&multisig_spec.ConstructorParams{
 				Signers:               []address.Address{alice},
@@ -67,7 +67,7 @@ func TestMultiSigActor(t *testing.T, factory state.Factories) {
 
 		multisigAddr := utils.NewIDAddr(t, 1+utils.IdFromAddress(outsiderId))
 
-		createRet := td.ComputeInitActorExecReturn(aliceId, 0, multisigAddr)
+		createRet := td.ComputeInitActorExecReturn(alice, 0, 0, multisigAddr)
 		// create the multisig actor
 		td.MustCreateAndVerifyMultisigActor(0, valueSend, multisigAddr, alice,
 			&multisig_spec.ConstructorParams{
@@ -144,6 +144,7 @@ func TestMultiSigActor(t *testing.T, factory state.Factories) {
 
 		// Multisig actor address
 		multisigAddr := utils.NewIDAddr(t, 1+utils.IdFromAddress(outsiderId))
+		createRet := td.ComputeInitActorExecReturn(alice, 0, 0, multisigAddr)
 
 		// create the multisig actor
 		td.MustCreateAndVerifyMultisigActor(0, valueSend, multisigAddr, alice,
@@ -154,7 +155,7 @@ func TestMultiSigActor(t *testing.T, factory state.Factories) {
 			},
 			types.MessageReceipt{
 				ExitCode:    exitcode_spec.Ok,
-				ReturnValue: multisigAddr.Bytes(),
+				ReturnValue: chain.MustSerialize(&createRet),
 				GasUsed:     big_spec.NewInt(1542),
 			})
 
@@ -233,6 +234,7 @@ func TestMultiSigActor(t *testing.T, factory state.Factories) {
 		var initialSigners = []address.Address{alice, bob}
 
 		multisigAddr := utils.NewIDAddr(t, 1+utils.IdFromAddress(duckId))
+		createRet := td.ComputeInitActorExecReturn(alice, 0, 0, multisigAddr)
 
 		td.MustCreateAndVerifyMultisigActor(0, valueSend, multisigAddr, alice,
 			&multisig_spec.ConstructorParams{
@@ -242,7 +244,7 @@ func TestMultiSigActor(t *testing.T, factory state.Factories) {
 			},
 			types.MessageReceipt{
 				ExitCode:    exitcode_spec.Ok,
-				ReturnValue: multisigAddr.Bytes(),
+				ReturnValue: chain.MustSerialize(&createRet),
 				GasUsed:     big_spec.NewInt(1794),
 			})
 
@@ -317,6 +319,7 @@ func TestMultiSigActor(t *testing.T, factory state.Factories) {
 		var initialSigners = []address.Address{aliceId, bobId, chuckId, duckId}
 
 		multisigAddr := utils.NewIDAddr(t, utils.IdFromAddress(duckId)+1)
+		createRet := td.ComputeInitActorExecReturn(alice, 0, 0, multisigAddr)
 
 		// create a ms actor with 4 signers and 3 approvals required
 		td.MustCreateAndVerifyMultisigActor(0, valueSend, multisigAddr, alice,
@@ -327,7 +330,7 @@ func TestMultiSigActor(t *testing.T, factory state.Factories) {
 			},
 			types.MessageReceipt{
 				ExitCode:    exitcode_spec.Ok,
-				ReturnValue: multisigAddr.Bytes(),
+				ReturnValue: chain.MustSerialize(&createRet),
 				GasUsed:     big_spec.NewInt(1680),
 			})
 
@@ -403,7 +406,7 @@ func TestMultiSigActor(t *testing.T, factory state.Factories) {
 		var initialSigners = []address.Address{aliceId, bobId}
 
 		multisigAddr := utils.NewIDAddr(t, utils.IdFromAddress(chuckId)+1)
-
+		createRet := td.ComputeInitActorExecReturn(alice, 0, 0, multisigAddr)
 		// create a ms actor with 4 signers and 3 approvals required
 		td.MustCreateAndVerifyMultisigActor(0, valueSend, multisigAddr, alice,
 			&multisig_spec.ConstructorParams{
@@ -413,7 +416,7 @@ func TestMultiSigActor(t *testing.T, factory state.Factories) {
 			},
 			types.MessageReceipt{
 				ExitCode:    exitcode_spec.Ok,
-				ReturnValue: multisigAddr.Bytes(),
+				ReturnValue: chain.MustSerialize(&createRet),
 				GasUsed:     big_spec.NewInt(1558),
 			})
 

--- a/suites/message/paych.go
+++ b/suites/message/paych.go
@@ -39,7 +39,7 @@ func TestPaych(t *testing.T, factory state.Factories) {
 
 		// the _expected_ address of the payment channel
 		paychAddr := utils.NewIDAddr(t, utils.IdFromAddress(receiverID)+1)
-		createRet := td.ComputeInitActorExecReturn(senderID, 0, paychAddr)
+		createRet := td.ComputeInitActorExecReturn(sender, 0, 0, paychAddr)
 
 		// init actor creates the payment channel
 		td.ApplyMessageExpectReceipt(
@@ -67,14 +67,14 @@ func TestPaych(t *testing.T, factory state.Factories) {
 		}
 
 		// will create and send on payment channel
-		sender, senderID := td.NewAccountActor(drivers.SECP, initialBal)
+		sender, _ := td.NewAccountActor(drivers.SECP, initialBal)
 
 		// will be receiver on paych
 		receiver, receiverID := td.NewAccountActor(drivers.SECP, initialBal)
 
 		// the _expected_ address of the payment channel
 		paychAddr := utils.NewIDAddr(t, utils.IdFromAddress(receiverID)+1)
-		createRet := td.ComputeInitActorExecReturn(senderID, 0, paychAddr)
+		createRet := td.ComputeInitActorExecReturn(sender, 0, 0, paychAddr)
 		td.ApplyMessageExpectReceipt(
 			td.MessageProducer.CreatePaymentChannelActor(receiver, sender, chain.Value(toSend), chain.Nonce(0)),
 			types.MessageReceipt{ExitCode: exitcode.Ok, ReturnValue: chain.MustSerialize(&createRet), GasUsed: createPaychGasCost},
@@ -106,10 +106,10 @@ func TestPaych(t *testing.T, factory state.Factories) {
 		td := builder.Build(t)
 
 		// create the payment channel
-		sender, senderID := td.NewAccountActor(drivers.SECP, initialBal)
+		sender, _ := td.NewAccountActor(drivers.SECP, initialBal)
 		receiver, receiverID := td.NewAccountActor(drivers.SECP, initialBal)
 		paychAddr := utils.NewIDAddr(t, utils.IdFromAddress(receiverID)+1)
-		initRet := td.ComputeInitActorExecReturn(senderID, 0, paychAddr)
+		initRet := td.ComputeInitActorExecReturn(sender, 0, 0, paychAddr)
 		td.ApplyMessageExpectReceipt(
 			td.MessageProducer.CreatePaymentChannelActor(receiver, sender, chain.Value(toSend), chain.Nonce(0)),
 			types.MessageReceipt{ExitCode: exitcode.Ok, ReturnValue: chain.MustSerialize(&initRet), GasUsed: createPaychGasCost},

--- a/suites/tipset/internal_message_failure.go
+++ b/suites/tipset/internal_message_failure.go
@@ -39,7 +39,7 @@ func TestInternalMessageApplicationFailure(t *testing.T, factory state.Factories
 
 		multisigAddr := utils.NewIDAddr(t, utils.IdFromAddress(aliceId)+1)
 
-		createRet := td.ComputeInitActorExecReturn(aliceId, 0, multisigAddr)
+		createRet := td.ComputeInitActorExecReturn(aliceId, 0, 1, multisigAddr)
 		// Create the multisig actor and propose the send
 		blkBuilder.WithTicketCount(1).
 			WithSECPMessageAndReceipt(
@@ -85,7 +85,7 @@ func TestInternalMessageApplicationFailure(t *testing.T, factory state.Factories
 		proposeParams := chain.MustSerialize(&params)
 		proposeParams[2] = address.Unknown // the 3rd byte in the slice is the address protocol identifier, set to invalid protocol
 
-		createRet := td.ComputeInitActorExecReturn(aliceId, 0, multisigAddr)
+		createRet := td.ComputeInitActorExecReturn(aliceId, 0, 1, multisigAddr)
 		blkBuilder.WithTicketCount(1).
 			WithSECPMessageAndReceipt(
 				signMessage(

--- a/suites/tipset/miner_flow.go
+++ b/suites/tipset/miner_flow.go
@@ -42,7 +42,7 @@ func TestMinerCreateProveCommitAndMissPoStChallengeWindow(t *testing.T, factory 
 	minerWorker, minerWorkerID := td.NewAccountActor(address.BLS, abi_spec.NewTokenAmount(1_000_000_000))
 	// The address of the miner actor
 	minerActorID := utils.NewIDAddr(t, utils.IdFromAddress(minerWorkerID)+1)
-	createMinerRet := td.ComputeInitActorExecReturn(builtin_spec.StoragePowerActorAddr, 0, minerActorID)
+	createMinerRet := td.ComputeInitActorExecReturn(minerOwner, 0, 1, minerActorID)
 	// collaterall the miner will pledge
 	collateral := abi_spec.NewTokenAmount(1_000_000)
 
@@ -71,7 +71,7 @@ func TestMinerCreateProveCommitAndMissPoStChallengeWindow(t *testing.T, factory 
 				minerActorID,
 				chain.Nonce(0), chain.Value(collateral),
 			),
-			types.MessageReceipt{ExitCode: exitcode_spec.Ok, ReturnValue: []byte{}, GasUsed: big_spec.Zero()},
+			types.MessageReceipt{ExitCode: exitcode_spec.Ok, ReturnValue: nil, GasUsed: big_spec.Zero()},
 		).
 		// Step 2.B: Add market funds for miner
 		WithBLSMessageAndReceipt(
@@ -79,7 +79,7 @@ func TestMinerCreateProveCommitAndMissPoStChallengeWindow(t *testing.T, factory 
 				minerWorker,
 				chain.Nonce(1), chain.Value(collateral),
 			),
-			types.MessageReceipt{ExitCode: exitcode_spec.Ok, ReturnValue: []byte{}, GasUsed: big_spec.Zero()},
+			types.MessageReceipt{ExitCode: exitcode_spec.Ok, ReturnValue: nil, GasUsed: big_spec.Zero()},
 		).
 		ApplyAndValidate()
 
@@ -118,7 +118,7 @@ func TestMinerCreateProveCommitAndMissPoStChallengeWindow(t *testing.T, factory 
 					Expiration:      sectorInfo.Deal.EndEpoch,
 				},
 				chain.Nonce(2), chain.Value(big_spec.Zero())),
-			types.MessageReceipt{ExitCode: exitcode_spec.Ok, ReturnValue: []byte{}, GasUsed: big_spec.Zero()},
+			types.MessageReceipt{ExitCode: exitcode_spec.Ok, ReturnValue: nil, GasUsed: big_spec.Zero()},
 		).
 		ApplyAndValidate()
 
@@ -130,7 +130,7 @@ func TestMinerCreateProveCommitAndMissPoStChallengeWindow(t *testing.T, factory 
 			td.MessageProducer.MinerProveCommitSector(minerActorID, minerWorker,
 				miner_spec.ProveCommitSectorParams{SectorNumber: sectorInfo.SectorID, Proof: nil},
 				chain.Value(big_spec.Zero()), chain.Nonce(3)),
-			types.MessageReceipt{ExitCode: exitcode_spec.Ok, ReturnValue: []byte{}, GasUsed: big_spec.Zero()},
+			types.MessageReceipt{ExitCode: exitcode_spec.Ok, ReturnValue: nil, GasUsed: big_spec.Zero()},
 		).
 		ApplyAndValidate()
 
@@ -147,7 +147,7 @@ func TestMinerCreateProveCommitAndMissPoStChallengeWindow(t *testing.T, factory 
 			td.MessageProducer.Transfer(minerOwner, minerOwner,
 				chain.Nonce(2), chain.Value(big_spec.Zero()),
 			),
-			types.MessageReceipt{ExitCode: exitcode_spec.Ok, ReturnValue: []byte{}, GasUsed: big_spec.Zero()},
+			types.MessageReceipt{ExitCode: exitcode_spec.Ok, ReturnValue: nil, GasUsed: big_spec.Zero()},
 		).
 		ApplyAndValidate()
 


### PR DESCRIPTION
**PR #113 should be merged first (or closed after this PR is merged)**

- provide internalCallSeqNum when calculating expected actor addresses
- use {idaddress, outer address} structs in expected message receipts
- use pubkey address, not ID address, to calculate expected message receipts
- expect txnId, not empty return, for multisig propose message