### PR TITLE
add a fallback PoSt test and refactor miner_flow

### DIFF
--- a/drivers/test.go
+++ b/drivers/test.go
@@ -53,6 +53,9 @@ var (
 	DefaultBuiltinActorsState      []ActorState
 )
 
+// if this number is 0 we get a specs-actors panic since it divides by 0
+const InitialTotalNetworkPower = 1
+
 func init() {
 	ms := newMockStore()
 	if err := initializeStoreWithAdtRoots(ms); err != nil {
@@ -85,7 +88,7 @@ func init() {
 		Balance: big_spec.Zero(),
 		Code:    builtin_spec.StoragePowerActorCodeID,
 		State: &power_spec.State{
-			TotalNetworkPower:        abi_spec.NewStoragePower(1),
+			TotalNetworkPower:        abi_spec.NewStoragePower(InitialTotalNetworkPower),
 			EscrowTable:              EmptyMapCid,
 			CronEventQueue:           EmptyMapCid,
 			PoStDetectedFaultMiners:  EmptyMapCid,
@@ -303,6 +306,12 @@ func (td *TestDriver) AssertBalance(addr address.Address, expected big_spec.Int)
 	actr, err := td.State().Actor(addr)
 	require.NoError(td.T, err)
 	assert.Equal(td.T, expected, actr.Balance(), fmt.Sprintf("expected balance: %v, actual balance: %v", expected, actr.Balance().String()))
+}
+func (td *TestDriver) AssertBalanceCallback(addr address.Address, thing func(actorBalance abi_spec.TokenAmount) bool) {
+	actr, err := td.State().Actor(addr)
+	require.NoError(td.T, err)
+	assert.True(td.T, thing(actr.Balance()))
+	//assert.True(td.T, , actr.Balance(), fmt.Sprintf("expected balance: %v, actual balance: %v", expected, actr.Balance().String()))
 }
 
 func (td *TestDriver) AssertReceipt(actual, expected types.MessageReceipt) {

--- a/suites/tipset/miner_flow.go
+++ b/suites/tipset/miner_flow.go
@@ -13,6 +13,7 @@ import (
 	power_spec "github.com/filecoin-project/specs-actors/actors/builtin/power"
 	crypto_spec "github.com/filecoin-project/specs-actors/actors/crypto"
 	exitcode_spec "github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/chain-validation/chain"
@@ -22,54 +23,56 @@ import (
 	"github.com/filecoin-project/chain-validation/suites/utils"
 )
 
-func TestMinerCreateProveCommitAndMissPoStChallengeWindow(t *testing.T, factory state.Factories) {
-	td := drivers.NewBuilder(context.Background(), factory).
-		WithDefaultGasLimit(1_000_000).
-		WithDefaultGasPrice(big_spec.NewInt(1)).
-		WithActorState(drivers.DefaultBuiltinActorsState).Build(t)
+func CreateMinerWithProvenCommittedSector(td *drivers.TestDriver, minerOwner, minerWorker, minerIDAddr address.Address, sectorType abi_spec.RegisteredProof, collateral abi_spec.TokenAmount, dealStart, dealEnd abi_spec.ChainEpoch) *types.PreSeal {
+	td.AssertBalanceCallback(minerOwner, func(actorBal abi_spec.TokenAmount) bool {
+		return actorBal.GreaterThanEqual(collateral)
+	})
+	td.AssertBalanceCallback(minerWorker, func(actorBal abi_spec.TokenAmount) bool {
+		return actorBal.GreaterThanEqual(collateral)
+	})
+
+	// since we do not know the callseq of this actor when this method is called
+	ownerActor, err := td.State().Actor(minerOwner)
+	require.NoError(td.T, err)
+	ownerCallSeq := ownerActor.CallSeqNum()
+	incOwnerCallSeq := func() int64 {
+		// fell down the ugly stack and hit every frame on the way down
+		defer func() { ownerCallSeq += 1 }()
+		return ownerCallSeq
+	}
+
+	workerActor, err := td.State().Actor(minerWorker)
+	require.NoError(td.T, err)
+	workerCallSeq := workerActor.CallSeqNum()
+	incWorkerCallSeq := func() int64 {
+		defer func() { workerCallSeq += 1 }()
+		return workerCallSeq
+	}
 
 	sectorBuilder := drivers.NewMockSectorBuilder()
-	blkBuilder := drivers.NewTipSetMessageBuilder(td)
+	bb := drivers.NewTipSetMessageBuilder(td)
 
-	//
-	// Define Parameters
-	//
+	sectorSize, err := sectorType.SectorSize()
+	require.NoError(td.T, err)
 
-	// The owner address is the address that created the miner, paid the collateral, and has block rewards paid out to it.
-	minerOwner, _ := td.NewAccountActor(address.SECP256K1, abi_spec.NewTokenAmount(1_000_000_000))
-	// minerWorker address will be responsible for doing all of the work, submitting proofs, committing new sectors,
-	// and all other day to day activities.
-	minerWorker, minerWorkerID := td.NewAccountActor(address.BLS, abi_spec.NewTokenAmount(1_000_000_000))
-	// The address of the miner actor
-	minerActorID := utils.NewIDAddr(t, utils.IdFromAddress(minerWorkerID)+1)
-	createMinerRet := td.ComputeInitActorExecReturn(minerOwner, 0, 1, minerActorID)
-	// collaterall the miner will pledge
-	collateral := abi_spec.NewTokenAmount(1_000_000)
-
-	sectorProofType := abi_spec.RegisteredProof_StackedDRG32GiBSeal
-	sectorSize, err := sectorProofType.SectorSize()
-	require.NoError(t, err)
-
-	//
-	// Apply messages and assert result
-	//
+	createMinerRet := td.ComputeInitActorExecReturn(builtin_spec.StoragePowerActorAddr, 0, 2, minerIDAddr)
 
 	// Create a miner and add finds to the storage market actor for the miner and a client
-	blkBuilder.WithTicketCount(1).
+	bb.WithTicketCount(1).
 		// Step 1: Register the miner with the power actor
 		WithBLSMessageAndReceipt(
 			td.MessageProducer.PowerCreateMiner(
 				builtin_spec.StoragePowerActorAddr, minerOwner,
-				power_spec.CreateMinerParams{Owner: minerOwner, Worker: minerWorker, SectorSize: sectorSize, Peer: utils.RequireRandomPeerID(t)},
-				chain.Nonce(0), chain.Value(collateral),
+				power_spec.CreateMinerParams{Owner: minerOwner, Worker: minerWorker, SectorSize: sectorSize, Peer: utils.RequireRandomPeerID(td.T)},
+				chain.Nonce(incOwnerCallSeq()), chain.Value(collateral),
 			),
 			types.MessageReceipt{ExitCode: exitcode_spec.Ok, ReturnValue: chain.MustSerialize(&createMinerRet), GasUsed: big_spec.Zero()},
 		).
 		// Step 2.A: Add market funds for client
 		WithBLSMessageAndReceipt(
 			td.MessageProducer.MarketAddBalance(builtin_spec.StorageMarketActorAddr, minerWorker,
-				minerActorID,
-				chain.Nonce(0), chain.Value(collateral),
+				minerIDAddr,
+				chain.Nonce(incWorkerCallSeq()), chain.Value(collateral),
 			),
 			types.MessageReceipt{ExitCode: exitcode_spec.Ok, ReturnValue: nil, GasUsed: big_spec.Zero()},
 		).
@@ -77,23 +80,21 @@ func TestMinerCreateProveCommitAndMissPoStChallengeWindow(t *testing.T, factory 
 		WithBLSMessageAndReceipt(
 			td.MessageProducer.MarketAddBalance(builtin_spec.StorageMarketActorAddr, minerOwner,
 				minerWorker,
-				chain.Nonce(1), chain.Value(collateral),
+				chain.Nonce(incOwnerCallSeq()), chain.Value(collateral),
 			),
 			types.MessageReceipt{ExitCode: exitcode_spec.Ok, ReturnValue: nil, GasUsed: big_spec.Zero()},
 		).
 		ApplyAndValidate()
 
-	dealStart := abi_spec.ChainEpoch(15)
-	dealEnd := abi_spec.ChainEpoch(1000)
 	// The miner preseals a sector
-	sectorInfo := sectorBuilder.NewPreSealedSector(minerActorID, minerWorker, sectorProofType, sectorSize, dealStart, dealEnd)
+	sectorInfo := sectorBuilder.NewPreSealedSector(minerIDAddr, minerWorker, sectorType, sectorSize, dealStart, dealEnd)
 
 	dealIDs := []abi_spec.DealID{abi_spec.DealID(0)}
 	pubRet := chain.MustSerialize(&market_spec.PublishStorageDealsReturn{IDs: dealIDs})
 
 	td.ExeCtx.Epoch++
 	// Miner publishes deal to the storage market and precommits its sector
-	blkBuilder.WithTicketCount(1).
+	bb.WithTicketCount(1).
 		// Step 3: Publish presealed deals
 		WithBLSMessageAndReceipt(
 			td.MessageProducer.MarketPublishStorageDeals(builtin_spec.StorageMarketActorAddr, minerWorker,
@@ -102,13 +103,13 @@ func TestMinerCreateProveCommitAndMissPoStChallengeWindow(t *testing.T, factory 
 						{Proposal: sectorInfo.Deal, ClientSignature: crypto_spec.Signature{Type: crypto_spec.SigTypeBLS, Data: []byte("doesnt matter")}},
 					},
 				},
-				chain.Nonce(1), chain.Value(big_spec.Zero()),
+				chain.Nonce(incWorkerCallSeq()), chain.Value(big_spec.Zero()),
 			),
 			types.MessageReceipt{ExitCode: exitcode_spec.Ok, ReturnValue: pubRet, GasUsed: big_spec.Zero()},
 		).
 		// Step 4: Pre Committing Sectors
 		WithBLSMessageAndReceipt(
-			td.MessageProducer.MinerPreCommitSector(minerActorID, minerWorker,
+			td.MessageProducer.MinerPreCommitSector(minerIDAddr, minerWorker,
 				miner_spec.SectorPreCommitInfo{
 					RegisteredProof: sectorInfo.ProofType,
 					SectorNumber:    sectorInfo.SectorID,
@@ -117,45 +118,159 @@ func TestMinerCreateProveCommitAndMissPoStChallengeWindow(t *testing.T, factory 
 					DealIDs:         dealIDs,
 					Expiration:      sectorInfo.Deal.EndEpoch,
 				},
-				chain.Nonce(2), chain.Value(big_spec.Zero())),
+				chain.Nonce(incWorkerCallSeq()), chain.Value(big_spec.Zero())),
 			types.MessageReceipt{ExitCode: exitcode_spec.Ok, ReturnValue: nil, GasUsed: big_spec.Zero()},
 		).
 		ApplyAndValidate()
 
 	// Miner prove commits its sector
 	td.ExeCtx.Epoch = dealStart
-	blkBuilder.WithTicketCount(1).
+	bb.WithTicketCount(1).
 		WithBLSMessageAndReceipt(
 			// Step 5: Prove the committed sector
-			td.MessageProducer.MinerProveCommitSector(minerActorID, minerWorker,
+			td.MessageProducer.MinerProveCommitSector(minerIDAddr, minerWorker,
 				miner_spec.ProveCommitSectorParams{SectorNumber: sectorInfo.SectorID, Proof: nil},
-				chain.Value(big_spec.Zero()), chain.Nonce(3)),
+				chain.Nonce(incWorkerCallSeq()), chain.Value(big_spec.Zero())),
 			types.MessageReceipt{ExitCode: exitcode_spec.Ok, ReturnValue: nil, GasUsed: big_spec.Zero()},
 		).
 		ApplyAndValidate()
 
-	// the miner has not failed to PoSt
-	var minerSt miner_spec.State
-	td.GetActorState(minerActorID, &minerSt)
-	require.False(t, minerSt.PoStState.HasFailedPost())
+	return sectorInfo
+}
+
+func TestMinerMissPoStChallengeWindow(t *testing.T, factory state.Factories) {
+	td := drivers.NewBuilder(context.Background(), factory).
+		WithDefaultGasLimit(1_000_000).
+		WithDefaultGasPrice(big_spec.NewInt(1)).
+		WithActorState(drivers.DefaultBuiltinActorsState).
+		Build(t)
+
+	bb := drivers.NewTipSetMessageBuilder(td)
+
+	// The owner address is the address that created the miner, paid the collateral, and has block rewards paid out to it.
+	minerOwner, _ := td.NewAccountActor(address.SECP256K1, abi_spec.NewTokenAmount(1_000_000_000))
+	// minerWorker address will be responsible for doing all of the work, submitting proofs, committing new sectors,
+	// and all other day to day activities.
+	minerWorker, minerWorkerID := td.NewAccountActor(address.BLS, abi_spec.NewTokenAmount(1_000_000_000))
+	// The address of the miner actor
+	minerActorID := utils.NewIDAddr(t, utils.IdFromAddress(minerWorkerID)+1)
+
+	collateral := abi_spec.NewTokenAmount(1_000_000)
+	sectorProofType := abi_spec.RegisteredProof_StackedDRG32GiBSeal
+	dealStart := abi_spec.ChainEpoch(15)
+	dealEnd := abi_spec.ChainEpoch(1000)
+
+	CreateMinerWithProvenCommittedSector(td, minerOwner, minerWorker, minerActorID, sectorProofType, collateral, dealStart, dealEnd)
+	require.Equal(t, dealStart, td.ExeCtx.Epoch)
+	// since we do not know the callseq of this actor when this method is called
+	ownerActor, err := td.State().Actor(minerOwner)
+	require.NoError(td.T, err)
+	ownerCallSeq := ownerActor.CallSeqNum()
+	incOwnerCallSeq := func() int64 {
+		ownerCallSeq++
+		return ownerCallSeq
+	}
 
 	// Epoch advances to the end of the proving window. Send a sing message to trigger the cron actor send
 	td.ExeCtx.Epoch += power_spec.WindowedPostChallengeDuration + miner_spec.ProvingPeriod
-	blkBuilder.WithTicketCount(1).
+	bb.WithTicketCount(1).
 		// Step 6: send a single message that causes the cron actor to trigger
 		WithBLSMessageAndReceipt(
 			td.MessageProducer.Transfer(minerOwner, minerOwner,
-				chain.Nonce(2), chain.Value(big_spec.Zero()),
+				chain.Nonce(incOwnerCallSeq()), chain.Value(big_spec.Zero()),
 			),
 			types.MessageReceipt{ExitCode: exitcode_spec.Ok, ReturnValue: nil, GasUsed: big_spec.Zero()},
 		).
 		ApplyAndValidate()
 
 	// after the application of the message and moving the epoch past the proving period the miner has had a fault
+	var minerSt miner_spec.State
 	td.GetActorState(minerActorID, &minerSt)
 	require.True(t, minerSt.PoStState.HasFailedPost())
 	require.Equal(t, int64(1), minerSt.PoStState.NumConsecutiveFailures)
 
 	// NB: the power actors TotalNetworkPower filed will not change since ConsensusMinerMinPower is larger than
 	// what would be a reasonable amount of sectors to seal in a test.
+}
+
+func TestMinerSubmitFallbackPoSt(t *testing.T, factory state.Factories) {
+	td := drivers.NewBuilder(context.Background(), factory).
+		WithDefaultGasLimit(1_000_000).
+		WithDefaultGasPrice(big_spec.NewInt(1)).
+		WithActorState(drivers.DefaultBuiltinActorsState).
+		Build(t)
+
+	bb := drivers.NewTipSetMessageBuilder(td)
+
+	// The owner address is the address that created the miner, paid the collateral, and has block rewards paid out to it.
+	minerOwner, _ := td.NewAccountActor(address.SECP256K1, abi_spec.NewTokenAmount(1_000_000_000))
+	// minerWorker address will be responsible for doing all of the work, submitting proofs, committing new sectors,
+	// and all other day to day activities.
+	minerWorker, minerWorkerID := td.NewAccountActor(address.BLS, abi_spec.NewTokenAmount(1_000_000_000))
+	// The address of the miner actor
+	minerActorID := utils.NewIDAddr(t, utils.IdFromAddress(minerWorkerID)+1)
+
+	collateral := abi_spec.NewTokenAmount(1_000_000)
+	sectorProofType := abi_spec.RegisteredProof_StackedDRG32GiBSeal
+	dealStart := abi_spec.ChainEpoch(15)
+	dealEnd := abi_spec.ChainEpoch(1000)
+
+	CreateMinerWithProvenCommittedSector(td, minerOwner, minerWorker, minerActorID, sectorProofType, collateral, dealStart, dealEnd)
+	require.Equal(t, dealStart, td.ExeCtx.Epoch)
+	// since we do not know the callseq of this actor when this method is called
+	workerActor, err := td.State().Actor(minerWorker)
+	require.NoError(td.T, err)
+	workerCallSeq := workerActor.CallSeqNum()
+	incWorkerCallSeq := func() int64 {
+		defer func() { workerCallSeq += 1 }()
+		return workerCallSeq
+	}
+
+	ownerActor, err := td.State().Actor(minerOwner)
+	require.NoError(td.T, err)
+	ownerCallSeq := ownerActor.CallSeqNum()
+	incOwnerCallSeq := func() int64 {
+		defer func() { ownerCallSeq += 1 }()
+		return ownerCallSeq
+	}
+
+	candidates := []abi_spec.PoStCandidate{{
+		RegisteredProof: abi_spec.RegisteredProof_StackedDRG32GiBPoSt,
+		ChallengeIndex:  0,
+	}}
+	proofs := []abi_spec.PoStProof{{
+		RegisteredProof: abi_spec.RegisteredProof_StackedDRG32GiBPoSt,
+		ProofBytes:      []byte("doesn't matter"),
+	}}
+
+	// move the epoch forward to be withing the proving period window.
+	td.ExeCtx.Epoch += power_spec.WindowedPostChallengeDuration + miner_spec.ProvingPeriod/2
+	bb.WithTicketCount(1).
+		WithBLSMessageAndReceipt(
+			td.MessageProducer.MinerSubmitWindowedPoSt(minerActorID, minerWorker, abi_spec.OnChainPoStVerifyInfo{Candidates: candidates, Proofs: proofs},
+				chain.Nonce(incWorkerCallSeq()), chain.Value(big_spec.Zero())),
+			types.MessageReceipt{ExitCode: exitcode_spec.Ok, ReturnValue: nil, GasUsed: big_spec.Zero()},
+		).
+		ApplyAndValidate()
+
+	// move the epoch outside of the proving window and send a message to trigger the cron actor
+	td.ExeCtx.Epoch += miner_spec.ProvingPeriod/2 + 1
+	bb.WithTicketCount(1).
+		// Step 6: send a single message that causes the cron actor to trigger
+		WithBLSMessageAndReceipt(
+			td.MessageProducer.Transfer(minerOwner, minerOwner,
+				chain.Nonce(incOwnerCallSeq()), chain.Value(big_spec.Zero()),
+			),
+			types.MessageReceipt{ExitCode: exitcode_spec.Ok, ReturnValue: nil, GasUsed: big_spec.Zero()},
+		).
+		ApplyAndValidate()
+
+	// after the application of the message and moving the epoch past the proving period the miner has not had a fault
+	var minerSt miner_spec.State
+	td.GetActorState(minerActorID, &minerSt)
+	assert.False(t, minerSt.PoStState.HasFailedPost())
+
+	var powerSt power_spec.State
+	td.GetActorState(builtin_spec.StoragePowerActorAddr, &powerSt)
+	assert.Equal(t, drivers.InitialTotalNetworkPower+int64(32<<30), powerSt.TotalNetworkPower.Int64())
 }

--- a/suites/utils/peerid.go
+++ b/suites/utils/peerid.go
@@ -27,7 +27,7 @@ func RandPeerID() (peer.ID, error) {
 }
 
 // RequireRandomPeerID returns a new libp2p peer ID or panics.
-func RequireRandomPeerID(t *testing.T) peer.ID {
+func RequireRandomPeerID(t testing.TB) peer.ID {
 	pid, err := RandPeerID()
 	require.NoError(t, err)
 	return pid

--- a/suites/validations.go
+++ b/suites/validations.go
@@ -27,6 +27,7 @@ func TipSetTestCases() []TestCase {
 		tipset.TestBlockMessageDeduplication,
 		tipset.TestInternalMessageApplicationFailure,
 		tipset.TestInvalidSenderAddress,
-		tipset.TestMinerCreateProveCommitAndMissPoStChallengeWindow,
+		tipset.TestMinerMissPoStChallengeWindow,
+		tipset.TestMinerSubmitFallbackPoSt,
 	}
 }


### PR DESCRIPTION
The PR does the following: 
- Defines a method `CreateMinerWithProvenCommittedSector` that creates a miner and commits a sector. This was extracted from `TestMinerCreateProveCommitAndMissPoStChallengeWindow`.
- Repaces `TestMinerCreateProveCommitAndMissPoStChallengeWindow` with `TestMinerMissPoStChallengeWindow`
- Add new tests `TestMinerSubmitFallbackPoSt`
