### PR TITLE
simplify message application assertion methods

### DIFF
--- a/drivers/test.go
+++ b/drivers/test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/filecoin-project/go-address"
 	market_spec "github.com/filecoin-project/specs-actors/actors/builtin/market"
+	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
 	"github.com/ipfs/go-cid"
 	datastore "github.com/ipfs/go-datastore"
 	blockstore "github.com/ipfs/go-ipfs-blockstore"
@@ -278,8 +279,19 @@ func (td *TestDriver) Complete() {
 	//td.GasMeter.Record()
 }
 
-// TODO for failure cases we should consider catching panics here else they appear in the test output and obfuscate successful tests.
-func (td *TestDriver) ApplyMessageExpectReceipt(msg *types.Message, expected types.MessageReceipt) int64 {
+func (td *TestDriver) ApplyMessageExpectSuccess(msg *types.Message) int64 {
+	return td.ApplyMessageExpectSuccessAndReturn(msg, nil)
+}
+
+func (td *TestDriver) ApplyMessageExpectSuccessAndReturn(msg *types.Message, retval []byte) int64 {
+	return td.ApplyMessageExpectCodeAndReturn(msg, exitcode.Ok, retval)
+}
+
+func (td *TestDriver) ApplyMessageExpectCode(msg *types.Message, code exitcode.ExitCode) int64 {
+	return td.ApplyMessageExpectCodeAndReturn(msg, code, nil)
+}
+
+func (td *TestDriver) ApplyMessageExpectCodeAndReturn(msg *types.Message, code exitcode.ExitCode, retval []byte) int64 {
 	prevState := td.State().Root()
 
 	receipt, err := td.validator.ApplyMessage(td.ExeCtx, td.State(), msg)
@@ -297,10 +309,10 @@ func (td *TestDriver) ApplyMessageExpectReceipt(msg *types.Message, expected typ
 		}
 	}
 	if td.Config.ValidateExitCode() {
-		assert.Equal(td.T, expected.ExitCode, receipt.ExitCode, "Expected ExitCode: %s Actual ExitCode: %s", expected.ExitCode.Error(), receipt.ExitCode.Error())
+		assert.Equal(td.T, code, receipt.ExitCode, "Expected ExitCode: %s Actual ExitCode: %s", code.Error(), receipt.ExitCode.Error())
 	}
 	if td.Config.ValidateReturnValue() {
-		assert.Equal(td.T, expected.ReturnValue, receipt.ReturnValue, "Expected ReturnValue: %v Actual ReturnValue: %v", expected.ReturnValue, receipt.ReturnValue)
+		assert.Equal(td.T, retval, receipt.ReturnValue, "Expected ReturnValue: %v Actual ReturnValue: %v", retval, receipt.ReturnValue)
 	}
 
 	// TODO in the very near future we will be validating the stateroot here, keep in back of head.
@@ -399,12 +411,11 @@ func computeInitActorExecReturn(t testing.TB, from address.Address, originatorCa
 	}
 }
 
-func (td *TestDriver) MustCreateAndVerifyMultisigActor(nonce int64, value abi_spec.TokenAmount, multisigAddr address.Address, from address.Address, params *multisig_spec.ConstructorParams, receipt types.MessageReceipt) {
+func (td *TestDriver) MustCreateAndVerifyMultisigActor(nonce int64, value abi_spec.TokenAmount, multisigAddr address.Address, from address.Address, params *multisig_spec.ConstructorParams, code exitcode.ExitCode, retval []byte) {
 	/* Create the Multisig actor*/
-	td.ApplyMessageExpectReceipt(
+	td.ApplyMessageExpectCodeAndReturn(
 		td.MessageProducer.CreateMultisigActor(from, params.Signers, params.UnlockDuration, params.NumApprovalsThreshold, chain.Nonce(nonce), chain.Value(value)),
-		receipt,
-	)
+		code, retval)
 	/* Assert the actor state was setup as expected */
 	pendingTxMap, err := adt_spec.MakeEmptyMap(newMockStore())
 	require.NoError(td.T, err)

--- a/drivers/test.go
+++ b/drivers/test.go
@@ -279,19 +279,19 @@ func (td *TestDriver) Complete() {
 	//td.GasMeter.Record()
 }
 
-func (td *TestDriver) ApplyMessageExpectSuccess(msg *types.Message) int64 {
-	return td.ApplyMessageExpectSuccessAndReturn(msg, nil)
+func (td *TestDriver) ApplyOk(msg *types.Message) int64 {
+	return td.ApplyExpect(msg, nil)
 }
 
-func (td *TestDriver) ApplyMessageExpectSuccessAndReturn(msg *types.Message, retval []byte) int64 {
-	return td.ApplyMessageExpectCodeAndReturn(msg, exitcode.Ok, retval)
+func (td *TestDriver) ApplyExpect(msg *types.Message, retval []byte) int64 {
+	return td.applyMessageExpectCodeAndReturn(msg, exitcode.Ok, retval)
 }
 
-func (td *TestDriver) ApplyMessageExpectCode(msg *types.Message, code exitcode.ExitCode) int64 {
-	return td.ApplyMessageExpectCodeAndReturn(msg, code, nil)
+func (td *TestDriver) ApplyFailure(msg *types.Message, code exitcode.ExitCode) int64 {
+	return td.applyMessageExpectCodeAndReturn(msg, code, nil)
 }
 
-func (td *TestDriver) ApplyMessageExpectCodeAndReturn(msg *types.Message, code exitcode.ExitCode, retval []byte) int64 {
+func (td *TestDriver) applyMessageExpectCodeAndReturn(msg *types.Message, code exitcode.ExitCode, retval []byte) int64 {
 	prevState := td.State().Root()
 
 	receipt, err := td.validator.ApplyMessage(td.ExeCtx, td.State(), msg)
@@ -413,7 +413,7 @@ func computeInitActorExecReturn(t testing.TB, from address.Address, originatorCa
 
 func (td *TestDriver) MustCreateAndVerifyMultisigActor(nonce int64, value abi_spec.TokenAmount, multisigAddr address.Address, from address.Address, params *multisig_spec.ConstructorParams, code exitcode.ExitCode, retval []byte) {
 	/* Create the Multisig actor*/
-	td.ApplyMessageExpectCodeAndReturn(
+	td.applyMessageExpectCodeAndReturn(
 		td.MessageProducer.CreateMultisigActor(from, params.Signers, params.UnlockDuration, params.NumApprovalsThreshold, chain.Nonce(nonce), chain.Value(value)),
 		code, retval)
 	/* Assert the actor state was setup as expected */

--- a/suites/message/create_actor.go
+++ b/suites/message/create_actor.go
@@ -11,7 +11,6 @@ import (
 	exitcode_spec "github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
 
 	"github.com/filecoin-project/chain-validation/chain"
-	"github.com/filecoin-project/chain-validation/chain/types"
 	"github.com/filecoin-project/chain-validation/drivers"
 	"github.com/filecoin-project/chain-validation/state"
 	"github.com/filecoin-project/chain-validation/suites/utils"
@@ -87,9 +86,9 @@ func TestAccountActorCreation(t *testing.T, factory state.Factories) {
 			defer td.Complete()
 
 			existingAccountAddr, _ := td.NewAccountActor(tc.existingActorType, tc.existingActorBal)
-			gasUsed := td.ApplyMessageExpectReceipt(
+			gasUsed := td.ApplyMessageExpectCode(
 				td.MessageProducer.Transfer(tc.newActorAddr, existingAccountAddr, chain.Value(tc.newActorInitBal), chain.Nonce(0)),
-				types.MessageReceipt{ExitCode: tc.expExitCode, ReturnValue: nil, GasUsed: tc.expGasCost},
+				tc.expExitCode,
 			)
 
 			// new actor balance will only exist if message was applied successfully.
@@ -121,13 +120,13 @@ func TestInitActorSequentialIDAddressCreate(t *testing.T, factory state.Factorie
 	firstInitRet := td.ComputeInitActorExecReturn(sender, 0, 0, firstPaychAddr)
 	secondInitRet := td.ComputeInitActorExecReturn(sender, 1, 0, secondPaychAddr)
 
-	td.ApplyMessageExpectReceipt(
+	td.ApplyMessageExpectSuccessAndReturn(
 		td.MessageProducer.CreatePaymentChannelActor(receiver, sender, chain.Value(toSend), chain.Nonce(0)),
-		types.MessageReceipt{ExitCode: exitcode_spec.Ok, ReturnValue: chain.MustSerialize(&firstInitRet), GasUsed: abi_spec.NewTokenAmount(1416)},
+		chain.MustSerialize(&firstInitRet),
 	)
 
-	td.ApplyMessageExpectReceipt(
-		td.MessageProducer.CreatePaymentChannelActor(receiver, sender, chain.Value(toSend), chain.Nonce(1)),
-		types.MessageReceipt{ExitCode: exitcode_spec.Ok, ReturnValue: chain.MustSerialize(&secondInitRet), GasUsed: abi_spec.NewTokenAmount(1506)},
+	td.ApplyMessageExpectSuccessAndReturn(
+		td.MessageProducer.CreatePaymentChannelActor(receiver, sender, chain.Value(toSend), chain.Nonce(0)),
+		chain.MustSerialize(&secondInitRet),
 	)
 }

--- a/suites/message/create_actor.go
+++ b/suites/message/create_actor.go
@@ -86,7 +86,7 @@ func TestAccountActorCreation(t *testing.T, factory state.Factories) {
 			defer td.Complete()
 
 			existingAccountAddr, _ := td.NewAccountActor(tc.existingActorType, tc.existingActorBal)
-			gasUsed := td.ApplyMessageExpectCode(
+			gasUsed := td.ApplyFailure(
 				td.MessageProducer.Transfer(tc.newActorAddr, existingAccountAddr, chain.Value(tc.newActorInitBal), chain.Nonce(0)),
 				tc.expExitCode,
 			)
@@ -120,12 +120,12 @@ func TestInitActorSequentialIDAddressCreate(t *testing.T, factory state.Factorie
 	firstInitRet := td.ComputeInitActorExecReturn(sender, 0, 0, firstPaychAddr)
 	secondInitRet := td.ComputeInitActorExecReturn(sender, 1, 0, secondPaychAddr)
 
-	td.ApplyMessageExpectSuccessAndReturn(
+	td.ApplyExpect(
 		td.MessageProducer.CreatePaymentChannelActor(receiver, sender, chain.Value(toSend), chain.Nonce(0)),
 		chain.MustSerialize(&firstInitRet),
 	)
 
-	td.ApplyMessageExpectSuccessAndReturn(
+	td.ApplyExpect(
 		td.MessageProducer.CreatePaymentChannelActor(receiver, sender, chain.Value(toSend), chain.Nonce(0)),
 		chain.MustSerialize(&secondInitRet),
 	)

--- a/suites/message/message_application.go
+++ b/suites/message/message_application.go
@@ -31,7 +31,7 @@ func TestMessageApplicationEdgecases(t *testing.T, factory state.Factories) {
 		defer td.Complete()
 
 		alice, _ := td.NewAccountActor(drivers.SECP, aliceBal)
-		td.ApplyMessageExpectCode(
+		td.ApplyFailure(
 			td.MessageProducer.Transfer(alice, alice, chain.Value(transferAmnt), chain.Nonce(0), chain.GasPrice(1), chain.GasLimit(8)),
 			exitcode.SysErrOutOfGas)
 	})
@@ -42,13 +42,13 @@ func TestMessageApplicationEdgecases(t *testing.T, factory state.Factories) {
 
 		alice, _ := td.NewAccountActor(drivers.SECP, aliceBal)
 		// Expect Message application to fail due to lack of gas
-		td.ApplyMessageExpectCode(
+		td.ApplyFailure(
 			td.MessageProducer.Transfer(alice, alice, chain.Value(transferAmnt), chain.Nonce(0), chain.GasPrice(10), chain.GasLimit(1)),
 			exitcode.SysErrOutOfGas)
 
 		// Expect Message application to fail due to lack of gas when sender address is unknown
 		unknown := utils.NewIDAddr(t, 10000000)
-		td.ApplyMessageExpectCode(
+		td.ApplyFailure(
 			td.MessageProducer.Transfer(alice, unknown, chain.Value(transferAmnt), chain.Nonce(0), chain.GasPrice(10), chain.GasLimit(1)),
 			exitcode.SysErrOutOfGas)
 	})
@@ -60,13 +60,13 @@ func TestMessageApplicationEdgecases(t *testing.T, factory state.Factories) {
 		alice, _ := td.NewAccountActor(drivers.SECP, aliceBal)
 
 		// Expect Message application to fail due to callseqnum being invalid: 1 instead of 0
-		td.ApplyMessageExpectCode(
+		td.ApplyFailure(
 			td.MessageProducer.Transfer(alice, alice, chain.Value(transferAmnt), chain.Nonce(1)),
 			exitcode.SysErrInvalidCallSeqNum)
 
 		// Expect message application to fail due to unknow actor when call seq num is also incorrect
 		unknown := utils.NewIDAddr(t, 10000000)
-		td.ApplyMessageExpectCode(
+		td.ApplyFailure(
 			td.MessageProducer.Transfer(alice, unknown, chain.Value(transferAmnt), chain.Nonce(1)),
 			exitcode.SysErrActorNotFound)
 	})
@@ -94,12 +94,12 @@ func TestMessageApplicationEdgecases(t *testing.T, factory state.Factories) {
 		// the _expected_ address of the payment channel
 		paychAddr := utils.NewIDAddr(t, utils.IdFromAddress(receiverID)+1)
 		createRet := td.ComputeInitActorExecReturn(sender, 0, 0, paychAddr)
-		td.ApplyMessageExpectSuccessAndReturn(
+		td.ApplyExpect(
 			td.MessageProducer.CreatePaymentChannelActor(receiver, sender, chain.Value(toSend), chain.Nonce(0)),
 			chain.MustSerialize(&createRet))
 
 		// message application fails due to invalid argument (signature).
-		td.ApplyMessageExpectCode(
+		td.ApplyFailure(
 			td.MessageProducer.PaychUpdateChannelState(paychAddr, sender, paych_spec.UpdateChannelStateParams{
 				Sv: paych_spec.SignedVoucher{
 					TimeLockMin: pcTimeLock,

--- a/suites/message/multisig.go
+++ b/suites/message/multisig.go
@@ -88,7 +88,7 @@ func TestMultiSigActor(t *testing.T, factory state.Factories) {
 		// TODO: stop using TxnIDParams since it's not being passed as params to any method.
 		// Just get the right serialized bytes for the return value.
 		btxid := chain.MustSerialize(&multisig_spec.TxnIDParams{ID: txID0})
-		td.ApplyMessageExpectSuccessAndReturn(
+		td.ApplyExpect(
 			td.MessageProducer.MultisigPropose(multisigAddr, alice, pparams, chain.Value(big_spec.Zero()), chain.Nonce(1)),
 			btxid[1:])
 
@@ -101,13 +101,13 @@ func TestMultiSigActor(t *testing.T, factory state.Factories) {
 		})
 
 		// bob cancels alice's transaction. This fails as bob did not create alice's transaction.
-		td.ApplyMessageExpectCode(
+		td.ApplyFailure(
 			td.MessageProducer.MultisigCancel(multisigAddr, bob, multisig_spec.TxnIDParams{ID: txID0}, chain.Value(big_spec.Zero()), chain.Nonce(0)),
 			exitcode_spec.ErrForbidden)
 
 		// alice cancels their transaction. The outsider doesn't receive any FIL, the multisig actor's balance is empty, and the
 		// transaction is canceled.
-		td.ApplyMessageExpectSuccess(
+		td.ApplyOk(
 			td.MessageProducer.MultisigCancel(multisigAddr, alice, multisig_spec.TxnIDParams{ID: txID0}, chain.Nonce(2), chain.Value(big_spec.Zero())),
 		)
 		td.AssertMultisigState(multisigAddr, multisig_spec.State{
@@ -160,7 +160,7 @@ func TestMultiSigActor(t *testing.T, factory state.Factories) {
 
 		// propose the transaction and assert it exists in the actor state
 		btxid := chain.MustSerialize(&multisig_spec.TxnIDParams{ID: txID0})
-		td.ApplyMessageExpectSuccessAndReturn(
+		td.ApplyExpect(
 			td.MessageProducer.MultisigPropose(multisigAddr, alice, pparams, chain.Value(big_spec.Zero()), chain.Nonce(1)),
 			btxid[1:])
 
@@ -173,7 +173,7 @@ func TestMultiSigActor(t *testing.T, factory state.Factories) {
 		})
 
 		// outsider proposes themselves to receive 'valueSend' FIL. This fails as they are not a signer.
-		td.ApplyMessageExpectCode(
+		td.ApplyFailure(
 			td.MessageProducer.MultisigPropose(multisigAddr, outsider, multisig_spec.ProposeParams{
 				To:     outsider,
 				Value:  valueSend,
@@ -183,7 +183,7 @@ func TestMultiSigActor(t *testing.T, factory state.Factories) {
 			exitcode_spec.ErrForbidden)
 
 		// outsider approves the value transfer alice sent. This fails as they are not a signer.
-		td.ApplyMessageExpectCode(
+		td.ApplyFailure(
 			td.MessageProducer.MultisigApprove(multisigAddr, outsider, multisig_spec.TxnIDParams{ID: txID0}, chain.Value(big_spec.Zero()), chain.Nonce(1)),
 			exitcode_spec.ErrForbidden)
 
@@ -192,7 +192,7 @@ func TestMultiSigActor(t *testing.T, factory state.Factories) {
 		balanceBefore := td.GetBalance(outsider)
 
 		// bob approves transfer of 'valueSend' FIL to outsider.
-		td.ApplyMessageExpectSuccess(
+		td.ApplyOk(
 			td.MessageProducer.MultisigApprove(multisigAddr, bob, multisig_spec.TxnIDParams{ID: txID0}, chain.Value(big_spec.Zero()), chain.Nonce(0)),
 		)
 		txID1 := multisig_spec.TxnID(1)
@@ -241,7 +241,7 @@ func TestMultiSigActor(t *testing.T, factory state.Factories) {
 		}
 
 		// alice fails to call directly since AddSigner
-		td.ApplyMessageExpectCode(
+		td.ApplyFailure(
 			td.MessageProducer.MultisigAddSigner(multisigAddr, alice, addSignerParams, chain.Nonce(1)),
 			exitcode_spec.SysErrForbidden,
 		)
@@ -252,7 +252,7 @@ func TestMultiSigActor(t *testing.T, factory state.Factories) {
 		// Alice proposes the AddSigner.
 		// Since approvals = 1 this auto-approves the transaction.
 		btxid := chain.MustSerialize(&multisig_spec.TxnIDParams{ID: txID0})
-		td.ApplyMessageExpectSuccessAndReturn(
+		td.ApplyExpect(
 			td.MessageProducer.MultisigPropose(multisigAddr, alice, multisig_spec.ProposeParams{
 				To:     multisigAddr,
 				Value:  big_spec.Zero(),

--- a/suites/message/multisig.go
+++ b/suites/message/multisig.go
@@ -12,7 +12,6 @@ import (
 	exitcode_spec "github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
 
 	"github.com/filecoin-project/chain-validation/chain"
-	"github.com/filecoin-project/chain-validation/chain/types"
 	"github.com/filecoin-project/chain-validation/drivers"
 	"github.com/filecoin-project/chain-validation/state"
 	"github.com/filecoin-project/chain-validation/suites/utils"
@@ -46,11 +45,7 @@ func TestMultiSigActor(t *testing.T, factory state.Factories) {
 				NumApprovalsThreshold: numApprovals,
 				UnlockDuration:        unlockDuration,
 			},
-			types.MessageReceipt{
-				ExitCode:    exitcode_spec.Ok,
-				ReturnValue: chain.MustSerialize(&createRet),
-				GasUsed:     big_spec.Zero(), // Ignored
-			})
+			exitcode_spec.Ok, chain.MustSerialize(&createRet))
 	})
 
 	t.Run("propose and cancel", func(t *testing.T) {
@@ -77,11 +72,7 @@ func TestMultiSigActor(t *testing.T, factory state.Factories) {
 				NumApprovalsThreshold: numApprovals,
 				UnlockDuration:        unlockDuration,
 			},
-			types.MessageReceipt{
-				ExitCode:    exitcode_spec.Ok,
-				ReturnValue: chain.MustSerialize(&createRet),
-				GasUsed:     big_spec.Zero(), // Ignored
-			})
+			exitcode_spec.Ok, chain.MustSerialize(&createRet))
 		td.AssertBalance(multisigAddr, valueSend)
 
 		// alice proposes that outsider should receive 'valueSend' FIL.
@@ -97,10 +88,10 @@ func TestMultiSigActor(t *testing.T, factory state.Factories) {
 		// TODO: stop using TxnIDParams since it's not being passed as params to any method.
 		// Just get the right serialized bytes for the return value.
 		btxid := chain.MustSerialize(&multisig_spec.TxnIDParams{ID: txID0})
-		td.ApplyMessageExpectReceipt(
+		td.ApplyMessageExpectSuccessAndReturn(
 			td.MessageProducer.MultisigPropose(multisigAddr, alice, pparams, chain.Value(big_spec.Zero()), chain.Nonce(1)),
-			types.MessageReceipt{ExitCode: exitcode_spec.Ok, ReturnValue: btxid[1:], GasUsed: big_spec.Zero()}, // Gas ignored
-		)
+			btxid[1:])
+
 		td.AssertMultisigTransaction(multisigAddr, txID0, multisig_spec.Transaction{
 			To:       pparams.To,
 			Value:    pparams.Value,
@@ -110,16 +101,14 @@ func TestMultiSigActor(t *testing.T, factory state.Factories) {
 		})
 
 		// bob cancels alice's transaction. This fails as bob did not create alice's transaction.
-		td.ApplyMessageExpectReceipt(
+		td.ApplyMessageExpectCode(
 			td.MessageProducer.MultisigCancel(multisigAddr, bob, multisig_spec.TxnIDParams{ID: txID0}, chain.Value(big_spec.Zero()), chain.Nonce(0)),
-			types.MessageReceipt{ExitCode: exitcode_spec.ErrForbidden, ReturnValue: drivers.EmptyReturnValue, GasUsed: big_spec.Zero()}, // Gas ignored
-		)
+			exitcode_spec.ErrForbidden)
 
 		// alice cancels their transaction. The outsider doesn't receive any FIL, the multisig actor's balance is empty, and the
 		// transaction is canceled.
-		td.ApplyMessageExpectReceipt(
+		td.ApplyMessageExpectSuccess(
 			td.MessageProducer.MultisigCancel(multisigAddr, alice, multisig_spec.TxnIDParams{ID: txID0}, chain.Nonce(2), chain.Value(big_spec.Zero())),
-			types.MessageReceipt{ExitCode: exitcode_spec.Ok, ReturnValue: drivers.EmptyReturnValue, GasUsed: big_spec.Zero()}, // Gas ignored
 		)
 		td.AssertMultisigState(multisigAddr, multisig_spec.State{
 			Signers:               []address.Address{aliceId, bobId},
@@ -158,11 +147,7 @@ func TestMultiSigActor(t *testing.T, factory state.Factories) {
 				NumApprovalsThreshold: numApprovals,
 				UnlockDuration:        unlockDuration,
 			},
-			types.MessageReceipt{
-				ExitCode:    exitcode_spec.Ok,
-				ReturnValue: chain.MustSerialize(&createRet),
-				GasUsed:     big_spec.NewInt(1542),
-			})
+			exitcode_spec.Ok, chain.MustSerialize(&createRet))
 
 		// setup propose expected values and params
 		txID0 := multisig_spec.TxnID(0)
@@ -175,10 +160,10 @@ func TestMultiSigActor(t *testing.T, factory state.Factories) {
 
 		// propose the transaction and assert it exists in the actor state
 		btxid := chain.MustSerialize(&multisig_spec.TxnIDParams{ID: txID0})
-		td.ApplyMessageExpectReceipt(
+		td.ApplyMessageExpectSuccessAndReturn(
 			td.MessageProducer.MultisigPropose(multisigAddr, alice, pparams, chain.Value(big_spec.Zero()), chain.Nonce(1)),
-			types.MessageReceipt{ExitCode: exitcode_spec.Ok, ReturnValue: btxid[1:], GasUsed: big_spec.Zero()}, // Gas ignored
-		)
+			btxid[1:])
+
 		td.AssertMultisigTransaction(multisigAddr, txID0, multisig_spec.Transaction{
 			To:       pparams.To,
 			Value:    pparams.Value,
@@ -188,30 +173,27 @@ func TestMultiSigActor(t *testing.T, factory state.Factories) {
 		})
 
 		// outsider proposes themselves to receive 'valueSend' FIL. This fails as they are not a signer.
-		td.ApplyMessageExpectReceipt(
+		td.ApplyMessageExpectCode(
 			td.MessageProducer.MultisigPropose(multisigAddr, outsider, multisig_spec.ProposeParams{
 				To:     outsider,
 				Value:  valueSend,
 				Method: builtin_spec.MethodSend,
 				Params: []byte{},
 			}, chain.Value(big_spec.Zero()), chain.Nonce(0)),
-			types.MessageReceipt{ExitCode: exitcode_spec.ErrForbidden, ReturnValue: drivers.EmptyReturnValue, GasUsed: big_spec.Zero()}, // Gas ignored
-		)
+			exitcode_spec.ErrForbidden)
 
 		// outsider approves the value transfer alice sent. This fails as they are not a signer.
-		td.ApplyMessageExpectReceipt(
+		td.ApplyMessageExpectCode(
 			td.MessageProducer.MultisigApprove(multisigAddr, outsider, multisig_spec.TxnIDParams{ID: txID0}, chain.Value(big_spec.Zero()), chain.Nonce(1)),
-			types.MessageReceipt{ExitCode: exitcode_spec.ErrForbidden, ReturnValue: drivers.EmptyReturnValue, GasUsed: big_spec.Zero()}, // Gas ignored
-		)
+			exitcode_spec.ErrForbidden)
 
 		// increment the epoch to unlock the funds
 		td.ExeCtx.Epoch += unlockDuration
 		balanceBefore := td.GetBalance(outsider)
 
 		// bob approves transfer of 'valueSend' FIL to outsider.
-		td.ApplyMessageExpectReceipt(
+		td.ApplyMessageExpectSuccess(
 			td.MessageProducer.MultisigApprove(multisigAddr, bob, multisig_spec.TxnIDParams{ID: txID0}, chain.Value(big_spec.Zero()), chain.Nonce(0)),
-			types.MessageReceipt{ExitCode: exitcode_spec.Ok, ReturnValue: drivers.EmptyReturnValue, GasUsed: big_spec.Zero()}, // Gas ignored
 		)
 		txID1 := multisig_spec.TxnID(1)
 		td.AssertMultisigState(multisigAddr, multisig_spec.State{
@@ -249,11 +231,9 @@ func TestMultiSigActor(t *testing.T, factory state.Factories) {
 				NumApprovalsThreshold: initialNumApprovals,
 				UnlockDuration:        0,
 			},
-			types.MessageReceipt{
-				ExitCode:    exitcode_spec.Ok,
-				ReturnValue: chain.MustSerialize(&createRet),
-				GasUsed:     big_spec.Zero(), // Gas ignored
-			})
+			exitcode_spec.Ok,
+			chain.MustSerialize(&createRet),
+		)
 
 		addSignerParams := multisig_spec.AddSignerParams{
 			Signer:   bobId,
@@ -261,13 +241,10 @@ func TestMultiSigActor(t *testing.T, factory state.Factories) {
 		}
 
 		// alice fails to call directly since AddSigner
-		td.ApplyMessageExpectReceipt(
+		td.ApplyMessageExpectCode(
 			td.MessageProducer.MultisigAddSigner(multisigAddr, alice, addSignerParams, chain.Nonce(1)),
-			types.MessageReceipt{
-				ExitCode:    exitcode_spec.SysErrForbidden,
-				ReturnValue: drivers.EmptyReturnValue,
-				GasUsed:     big_spec.Zero(), // Gas ignored
-			})
+			exitcode_spec.SysErrForbidden,
+		)
 
 		// AddSigner must be staged through the multisig itself
 		txID0 := multisig_spec.TxnID(0)
@@ -275,14 +252,14 @@ func TestMultiSigActor(t *testing.T, factory state.Factories) {
 		// Alice proposes the AddSigner.
 		// Since approvals = 1 this auto-approves the transaction.
 		btxid := chain.MustSerialize(&multisig_spec.TxnIDParams{ID: txID0})
-		td.ApplyMessageExpectReceipt(
+		td.ApplyMessageExpectSuccessAndReturn(
 			td.MessageProducer.MultisigPropose(multisigAddr, alice, multisig_spec.ProposeParams{
 				To:     multisigAddr,
 				Value:  big_spec.Zero(),
 				Method: builtin_spec.MethodsMultisig.AddSigner,
 				Params: chain.MustSerialize(&addSignerParams),
 			}, chain.Nonce(2)),
-			types.MessageReceipt{ExitCode: exitcode_spec.Ok, ReturnValue: btxid[1:], GasUsed: big_spec.Zero()}, // Gas ignored
+			btxid[1:],
 		)
 
 		// TODO also exercise the approvals = 2 case with explicit approval.

--- a/suites/message/paych.go
+++ b/suites/message/paych.go
@@ -40,7 +40,7 @@ func TestPaych(t *testing.T, factory state.Factories) {
 		createRet := td.ComputeInitActorExecReturn(sender, 0, 0, paychAddr)
 
 		// init actor creates the payment channel
-		td.ApplyMessageExpectSuccessAndReturn(
+		td.ApplyExpect(
 			td.MessageProducer.CreatePaymentChannelActor(receiver, sender, chain.Value(toSend), chain.Nonce(0)),
 			chain.MustSerialize(&createRet))
 
@@ -73,11 +73,11 @@ func TestPaych(t *testing.T, factory state.Factories) {
 		// the _expected_ address of the payment channel
 		paychAddr := utils.NewIDAddr(t, utils.IdFromAddress(receiverID)+1)
 		createRet := td.ComputeInitActorExecReturn(sender, 0, 0, paychAddr)
-		td.ApplyMessageExpectSuccessAndReturn(
+		td.ApplyExpect(
 			td.MessageProducer.CreatePaymentChannelActor(receiver, sender, chain.Value(toSend), chain.Nonce(0)),
 			chain.MustSerialize(&createRet))
 
-		td.ApplyMessageExpectSuccess(
+		td.ApplyOk(
 			td.MessageProducer.PaychUpdateChannelState(paychAddr, sender, paych_spec.UpdateChannelStateParams{
 				Sv: paych_spec.SignedVoucher{
 					TimeLockMin: pcTimeLock,
@@ -106,12 +106,12 @@ func TestPaych(t *testing.T, factory state.Factories) {
 		receiver, receiverID := td.NewAccountActor(drivers.SECP, initialBal)
 		paychAddr := utils.NewIDAddr(t, utils.IdFromAddress(receiverID)+1)
 		initRet := td.ComputeInitActorExecReturn(sender, 0, 0, paychAddr)
-		td.ApplyMessageExpectSuccessAndReturn(
+		td.ApplyExpect(
 			td.MessageProducer.CreatePaymentChannelActor(receiver, sender, chain.Value(toSend), chain.Nonce(0)),
 			chain.MustSerialize(&initRet))
 		td.AssertBalance(paychAddr, toSend)
 
-		td.ApplyMessageExpectSuccess(
+		td.ApplyOk(
 			td.MessageProducer.PaychUpdateChannelState(paychAddr, sender, paych_spec.UpdateChannelStateParams{
 				Sv: paych_spec.SignedVoucher{
 					TimeLockMin: abi_spec.ChainEpoch(1),
@@ -127,13 +127,13 @@ func TestPaych(t *testing.T, factory state.Factories) {
 			}, chain.Nonce(1), chain.Value(big_spec.Zero())))
 
 		// settle the payment channel so it may be collected
-		settlePayChGasCost := td.ApplyMessageExpectSuccess(
+		settlePayChGasCost := td.ApplyOk(
 			td.MessageProducer.PaychSettle(paychAddr, receiver, adt_spec.EmptyValue{}, chain.Value(big_spec.Zero()), chain.Nonce(0)))
 
 		// advance the epoch so the funds may be redeemed.
 		td.ExeCtx.Epoch++
 
-		collectPaychGasCost := td.ApplyMessageExpectSuccess(
+		collectPaychGasCost := td.ApplyOk(
 			td.MessageProducer.PaychCollect(paychAddr, receiver, adt_spec.EmptyValue{}, chain.Nonce(1), chain.Value(big_spec.Zero())))
 
 		// receiver_balance = initial_balance + paych_send - settle_paych_msg_gas - collect_paych_msg_gas

--- a/suites/message/transfer.go
+++ b/suites/message/transfer.go
@@ -116,7 +116,7 @@ func TestValueTransferSimple(t *testing.T, factories state.Factories) {
 			require.NoError(t, err)
 			require.Equal(t, tc.senderBal.String(), sendAct.Balance().String())
 
-			gasUsed := td.ApplyMessageExpectCode(
+			gasUsed := td.ApplyFailure(
 				td.MessageProducer.Transfer(tc.receiver, tc.sender, chain.Value(tc.transferAmnt), chain.Nonce(0)),
 				tc.code,
 			)
@@ -147,7 +147,7 @@ func TestValueTransferAdvance(t *testing.T, factory state.Factories) {
 		alice, _ := td.NewAccountActor(drivers.SECP, aliceInitialBalance)
 		transferAmnt := abi_spec.NewTokenAmount(10)
 
-		gasUsed := td.ApplyMessageExpectSuccess(
+		gasUsed := td.ApplyOk(
 			td.MessageProducer.Transfer(alice, alice, chain.Value(transferAmnt), chain.Nonce(0)))
 		// since this is a self transfer expect alice's balance to only decrease by the gasUsed
 		td.AssertBalance(alice, big_spec.Sub(aliceInitialBalance, abi_spec.NewTokenAmount(gasUsed)))
@@ -161,7 +161,7 @@ func TestValueTransferAdvance(t *testing.T, factory state.Factories) {
 		unknown := td.Wallet().NewSECP256k1AccountAddress()
 		transferAmnt := abi_spec.NewTokenAmount(10)
 
-		gasUsed := td.ApplyMessageExpectSuccess(
+		gasUsed := td.ApplyOk(
 			td.MessageProducer.Transfer(unknown, alice, chain.Value(transferAmnt), chain.Nonce(0)),
 		)
 		td.AssertBalance(alice, big_spec.Sub(big_spec.Sub(aliceInitialBalance, abi_spec.NewTokenAmount(gasUsed)), transferAmnt))
@@ -176,7 +176,7 @@ func TestValueTransferAdvance(t *testing.T, factory state.Factories) {
 		unknown := td.Wallet().NewSECP256k1AccountAddress()
 		transferAmnt := abi_spec.NewTokenAmount(10)
 
-		td.ApplyMessageExpectCode(
+		td.ApplyFailure(
 			td.MessageProducer.Transfer(alice, unknown, chain.Value(transferAmnt), chain.Nonce(0)),
 			exitcode.SysErrActorNotFound)
 		td.Complete()
@@ -190,7 +190,7 @@ func TestValueTransferAdvance(t *testing.T, factory state.Factories) {
 		nobody := td.Wallet().NewSECP256k1AccountAddress()
 		transferAmnt := abi_spec.NewTokenAmount(10)
 
-		td.ApplyMessageExpectCode(
+		td.ApplyFailure(
 			td.MessageProducer.Transfer(nobody, unknown, chain.Value(transferAmnt), chain.Nonce(0)),
 			exitcode.SysErrActorNotFound)
 	})


### PR DESCRIPTION
This will likely cause conflicts with other inflight work (cc @anorth) going to hold off on merging

This PR replaces usage of `ApplyMessageExpectReceipt` with these new methods:
```go
ApplyMessageExpectSuccess(msg *types.Message) int64
ApplyMessageExpectCode(msg *types.Message, code exitcode.ExitCode) int64
ApplyMessageExpectSuccessAndReturn(msg *types.Message, retval []byte) int64
ApplyMessageExpectCodeAndReturn(msg *types.Message, code exitcode.ExitCode, retval []byte) int64
```
all methods return the gasuints used for further assertions.
