### PR TITLE
Remove unnecessarily skipped balance checks

### DIFF
--- a/suites/message/create_actor.go
+++ b/suites/message/create_actor.go
@@ -95,9 +95,7 @@ func TestAccountActorCreation(t *testing.T, factory state.Factories) {
 			// new actor balance will only exist if message was applied successfully.
 			if tc.expExitCode.IsSuccess() {
 				td.AssertBalance(tc.newActorAddr, tc.newActorInitBal)
-				if td.Config.ValidateGas() {
-					td.AssertBalance(existingAccountAddr, big_spec.Sub(big_spec.Sub(tc.existingActorBal, big_spec.NewInt(gasUsed)), tc.newActorInitBal))
-				}
+				td.AssertBalance(existingAccountAddr, big_spec.Sub(big_spec.Sub(tc.existingActorBal, big_spec.NewInt(gasUsed)), tc.newActorInitBal))
 			}
 		})
 	}

--- a/suites/message/paych.go
+++ b/suites/message/paych.go
@@ -151,9 +151,7 @@ func TestPaych(t *testing.T, factory state.Factories) {
 		)
 
 		// receiver_balance = initial_balance + paych_send - settle_paych_msg_gas - collect_paych_msg_gas
-		if td.Config.ValidateGas() {
-			td.AssertBalance(receiver, big_spec.Sub(big_spec.Sub(big_spec.Add(toSend, initialBal), abi_spec.NewTokenAmount(settlePayChGasCost)), abi_spec.NewTokenAmount(collectPaychGasCost)))
-		}
+		td.AssertBalance(receiver, big_spec.Sub(big_spec.Sub(big_spec.Add(toSend, initialBal), abi_spec.NewTokenAmount(settlePayChGasCost)), abi_spec.NewTokenAmount(collectPaychGasCost)))
 		td.AssertBalance(paychAddr, big_spec.Zero())
 		var pcState paych_spec.State
 		td.GetActorState(paychAddr, &pcState)

--- a/suites/message/transfer.go
+++ b/suites/message/transfer.go
@@ -140,9 +140,7 @@ func TestValueTransferSimple(t *testing.T, factories state.Factories) {
 			// create a message to transfer funds from `to` to `from` for amount `transferAmnt` and apply it to the state tree
 			// assert the actor balances changed as expected, the receiver balance should not change if transfer fails
 			if tc.receipt.ExitCode.IsSuccess() {
-				if td.Config.ValidateGas() {
-					td.AssertBalance(tc.sender, big_spec.Sub(big_spec.Sub(tc.senderBal, tc.transferAmnt), big_spec.NewInt(gasUsed)))
-				}
+				td.AssertBalance(tc.sender, big_spec.Sub(big_spec.Sub(tc.senderBal, tc.transferAmnt), big_spec.NewInt(gasUsed)))
 				td.AssertBalance(tc.receiver, tc.transferAmnt)
 			} else {
 				td.AssertBalance(tc.sender, tc.senderBal)
@@ -171,9 +169,7 @@ func TestValueTransferAdvance(t *testing.T, factory state.Factories) {
 			types.MessageReceipt{ExitCode: exitcode.Ok, ReturnValue: drivers.EmptyReturnValue, GasUsed: big_spec.Zero()},
 		)
 		// since this is a self transfer expect alice's balance to only decrease by the gasUsed
-		if td.Config.ValidateGas() {
-			td.AssertBalance(alice, big_spec.Sub(aliceInitialBalance, abi_spec.NewTokenAmount(gasUsed)))
-		}
+		td.AssertBalance(alice, big_spec.Sub(aliceInitialBalance, abi_spec.NewTokenAmount(gasUsed)))
 	})
 
 	t.Run("transfer from known address to unknown account", func(t *testing.T) {
@@ -188,9 +184,7 @@ func TestValueTransferAdvance(t *testing.T, factory state.Factories) {
 			td.MessageProducer.Transfer(unknown, alice, chain.Value(transferAmnt), chain.Nonce(0)),
 			types.MessageReceipt{ExitCode: exitcode.Ok, ReturnValue: drivers.EmptyReturnValue, GasUsed: big_spec.Zero()},
 		)
-		if td.Config.ValidateGas() {
-			td.AssertBalance(alice, big_spec.Sub(big_spec.Sub(aliceInitialBalance, abi_spec.NewTokenAmount(gasUsed)), transferAmnt))
-		}
+		td.AssertBalance(alice, big_spec.Sub(big_spec.Sub(aliceInitialBalance, abi_spec.NewTokenAmount(gasUsed)), transferAmnt))
 		td.AssertBalance(unknown, transferAmnt)
 	})
 


### PR DESCRIPTION
This reverts part of #118, which disabled balance checking because it used the expected gas value rather than the actual gas value.

I meant to include this in #124