### PR TITLE
Fix and clean up internal message send tipset test

### DIFF
--- a/suites/message/nested.go
+++ b/suites/message/nested.go
@@ -1,0 +1,104 @@
+package message
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/filecoin-project/specs-actors/actors/abi/big"
+	builtin "github.com/filecoin-project/specs-actors/actors/builtin"
+	init_ "github.com/filecoin-project/specs-actors/actors/builtin/init"
+	"github.com/filecoin-project/specs-actors/actors/builtin/multisig"
+	"github.com/filecoin-project/specs-actors/actors/runtime"
+	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/chain-validation/chain"
+	"github.com/filecoin-project/chain-validation/chain/types"
+	"github.com/filecoin-project/chain-validation/drivers"
+	"github.com/filecoin-project/chain-validation/state"
+)
+
+// Tests exercising messages sent internally from one actor to another.
+// These use a multisig actor with approvers=1 as a convenient staging ground for arbitrary internal messages.
+func TestNestedSends(t *testing.T, factory state.Factories) {
+	var acctDefaultBalance = abi.NewTokenAmount(1_000_000_000)
+	var multisigBalance = abi.NewTokenAmount(1_000_000)
+
+	builder := drivers.NewBuilder(context.Background(), factory).
+		WithDefaultGasLimit(1_000_000).
+		WithDefaultGasPrice(big.NewInt(1)).
+		WithActorState(drivers.DefaultBuiltinActorsState)
+
+	t.Run("ok basic send", func(t *testing.T) {
+		td := builder.Build(t)
+		defer td.Complete()
+
+		_, aliceId := td.NewAccountActor(drivers.SECP, acctDefaultBalance)
+
+		stage := prepareStage(td, aliceId, multisigBalance, 0)
+		balanceBefore := td.GetBalance(aliceId)
+
+		amtSent := abi.NewTokenAmount(1)
+		recpt := stage.send(aliceId, amtSent, builtin.MethodSend, nil, 1)
+		assert.Equal(t, exitcode.Ok, recpt.ExitCode)
+		balanceAfter := td.GetBalance(aliceId)
+
+		assert.Equal(t, big.Sub(big.Add(balanceBefore, amtSent), recpt.GasUsed), balanceAfter)
+	})
+
+	// TODO more tests:
+	// ok send to new actor
+	// ok send to self (the multisig)
+	// fail send to invalid address
+	// fail send negative value
+	// fail send running out of gas on inner method
+	// fail send to non-existent {ID|actor} address
+	// fail send empty params to method with params
+	// fail send non-CBOR params
+	// fail send wrong shape params to method
+	// fail send {existing|new} actor with invalid method id (replace TestInternalMessageApplicationFailure)
+	// fail send when target method aborts
+}
+
+// Wraps a multisig actor as a stage for nested sends.
+type ms_stage struct {
+	driver   *drivers.TestDriver
+	multisig address.Address
+	signer   address.Address
+}
+
+// Creates a multisig actor with its creator as sole approver.
+func prepareStage(td *drivers.TestDriver, creatorId address.Address, value abi.TokenAmount, creatorNonce int64) *ms_stage {
+	msg := td.MessageProducer.CreateMultisigActor(creatorId, []address.Address{creatorId}, 0, 1, chain.Value(value), chain.Nonce(creatorNonce))
+	receipt := td.ApplyMessage(msg)
+	require.Equal(td.T, exitcode.Ok, receipt.ExitCode)
+	var ret init_.ExecReturn
+	err := ret.UnmarshalCBOR(bytes.NewReader(receipt.ReturnValue))
+	require.NoError(td.T, err)
+
+	return &ms_stage{
+		driver:   td,
+		multisig: ret.IDAddress,
+		signer:   creatorId,
+	}
+}
+
+func (s *ms_stage) send(to address.Address, value abi.TokenAmount, method abi.MethodNum, params runtime.CBORMarshaler, approverNonce int64) types.MessageReceipt {
+	buf := bytes.Buffer{}
+	if params != nil {
+		err := params.MarshalCBOR(&buf)
+		require.NoError(s.driver.T, err)
+	}
+	pparams := multisig.ProposeParams{
+		To:     to,
+		Value:  value,
+		Method: method,
+		Params: buf.Bytes(),
+	}
+	msg := s.driver.MessageProducer.MultisigPropose(s.multisig, s.signer, pparams, chain.Nonce(approverNonce))
+	return s.driver.ApplyMessage(msg)
+}

--- a/suites/message/transfer.go
+++ b/suites/message/transfer.go
@@ -70,7 +70,6 @@ func TestValueTransferSimple(t *testing.T, factories state.Factories) {
 			code: exitcode.Ok,
 		},
 		{
-			// Note: this test current fails for lotus as it returns an error instead of a message receipt
 			desc: "fail to transfer more funds than sender balance > 0",
 
 			sender:    alice,
@@ -84,7 +83,6 @@ func TestValueTransferSimple(t *testing.T, factories state.Factories) {
 			code: exitcode.SysErrInsufficientFunds,
 		},
 		{
-			// Note: this test current fails for lotus as it returns an error instead of a message receipt
 			desc: "fail to transfer more funds than sender has when sender balance == zero",
 
 			sender:    alice,

--- a/suites/tipset/internal_message_failure.go
+++ b/suites/tipset/internal_message_failure.go
@@ -5,15 +5,14 @@ import (
 	"testing"
 
 	"github.com/filecoin-project/go-address"
-	abi_spec "github.com/filecoin-project/specs-actors/actors/abi"
-	big_spec "github.com/filecoin-project/specs-actors/actors/abi/big"
-	builtin_spec "github.com/filecoin-project/specs-actors/actors/builtin"
-	init_spec "github.com/filecoin-project/specs-actors/actors/builtin/init"
-
-	multisig_spec "github.com/filecoin-project/specs-actors/actors/builtin/multisig"
+	"github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/filecoin-project/specs-actors/actors/abi/big"
+	init_ "github.com/filecoin-project/specs-actors/actors/builtin/init"
+	"github.com/filecoin-project/specs-actors/actors/builtin/multisig"
 	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	typegen "github.com/whyrusleeping/cbor-gen"
 
 	"github.com/filecoin-project/chain-validation/chain"
 	"github.com/filecoin-project/chain-validation/chain/types"
@@ -25,45 +24,38 @@ import (
 func TestInternalMessageApplicationFailure(t *testing.T, factory state.Factories) {
 	builder := drivers.NewBuilder(context.Background(), factory).
 		WithDefaultGasLimit(1_000_000).
-		WithDefaultGasPrice(big_spec.NewInt(1)).
+		WithDefaultGasPrice(big.NewInt(1)).
 		WithActorState(drivers.DefaultBuiltinActorsState)
 
 	t.Run("multisig internal message send fails and receiver of message does not exist in state", func(t *testing.T) {
 		td := builder.Build(t)
 		blkBuilder := drivers.NewTipSetMessageBuilder(td)
 
-		_, aliceId := td.NewAccountActor(drivers.SECP, abi_spec.NewTokenAmount(2_000_000_000_000))
-
-		// this address should not exist since the propose is sent to the wrong account actor method
-		nobody := utils.NewSECP256K1Addr(t, "pubbub")
+		alice, aliceId := td.NewAccountActor(drivers.SECP, abi.NewTokenAmount(2_000_000_000_000))
 
 		multisigAddr := utils.NewIDAddr(t, utils.IdFromAddress(aliceId)+1)
+		createRet := td.ComputeInitActorExecReturn(alice, 0, 0, multisigAddr)
+		txID0 := typegen.CborInt(multisig.TxnID(0))
 
-		createRet := td.ComputeInitActorExecReturn(aliceId, 0, 1, multisigAddr)
+		target := utils.NewSECP256K1Addr(t, "pubbub")
+		proposeParams := multisig.ProposeParams{To: target, Value: big.Zero(), Method: 99, Params: nil} // Note invalid method ID
+
 		// Create the multisig actor and propose the send
 		blkBuilder.WithTicketCount(1).
 			WithSECPMessageAndReceipt(
-				signMessage(
-					td.MessageProducer.CreateMultisigActor(aliceId,
-						[]address.Address{aliceId}, 10, 1,
-						chain.Nonce(0), chain.Value(big_spec.Zero())),
-					td.Wallet()),
-				types.MessageReceipt{ExitCode: exitcode.Ok, ReturnValue: chain.MustSerialize(&createRet), GasUsed: abi_spec.NewTokenAmount(1282)},
+				signMessage(td.MessageProducer.CreateMultisigActor(aliceId, []address.Address{aliceId}, 0, 1, chain.Nonce(0)), td.Wallet()),
+				types.MessageReceipt{ExitCode: exitcode.Ok, ReturnValue: chain.MustSerialize(&createRet), GasUsed: abi.NewTokenAmount(1282)},
 			).
 			WithSECPMessageAndReceipt(
-				signMessage(
-					td.MessageProducer.MultisigPropose(multisigAddr, aliceId,
-						multisig_spec.ProposeParams{To: nobody, Value: big_spec.Zero(), Method: 99, Params: nil},
-						chain.Nonce(1), chain.Value(big_spec.Zero())),
-					td.Wallet()),
-				types.MessageReceipt{ExitCode: exitcode.Ok, ReturnValue: drivers.EmptyReturnValue, GasUsed: abi_spec.NewTokenAmount(1235)},
+				signMessage(td.MessageProducer.MultisigPropose(multisigAddr, aliceId, proposeParams, chain.Nonce(1)), td.Wallet()),
+				types.MessageReceipt{ExitCode: exitcode.Ok, ReturnValue: chain.MustSerialize(&txID0), GasUsed: abi.NewTokenAmount(1235)},
 			).
 			ApplyAndValidate()
 
 		// assert we get an error when attempting to get the actor that should not exist
-		_, err := td.State().Actor(nobody)
+		_, err := td.State().Actor(target)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), init_spec.ErrAddressNotFound.Error())
+		require.Contains(t, err.Error(), init_.ErrAddressNotFound.Error())
 	})
 
 	t.Run("multisig internal message send fails when receiver is invalid address protocol", func(t *testing.T) {
@@ -71,42 +63,31 @@ func TestInternalMessageApplicationFailure(t *testing.T, factory state.Factories
 		blkBuilder := drivers.NewTipSetMessageBuilder(td)
 
 		// create the multisig actor, set number of approvals to 1 so propose goes through on first send.
-		_, aliceId := td.NewAccountActor(drivers.SECP, abi_spec.NewTokenAmount(2_000_000_000_000))
+		alice, aliceId := td.NewAccountActor(drivers.SECP, abi.NewTokenAmount(2_000_000_000_000))
 		multisigAddr := utils.NewIDAddr(t, utils.IdFromAddress(aliceId)+1)
 
-		// this address will be changed to protocol Unknown after its been serialized into bytes for a parameter.
-		nobody := utils.NewSECP256K1Addr(t, "pubbbub")
-		params := multisig_spec.ProposeParams{
-			To:     nobody,
-			Value:  big_spec.Zero(),
-			Method: 0,
-			Params: nil,
-		}
-		proposeParams := chain.MustSerialize(&params)
-		proposeParams[2] = address.Unknown // the 3rd byte in the slice is the address protocol identifier, set to invalid protocol
+		invalidAddress := utils.NewSECP256K1Addr(t, "pubbbub")
+		invalidAddress.Bytes()[0] = address.Unknown // Exploit imperfect immutability of address to mutate its internals.
+		params := multisig.ProposeParams{To: invalidAddress, Value: big.Zero(), Method: 0, Params: nil}
 
-		createRet := td.ComputeInitActorExecReturn(aliceId, 0, 1, multisigAddr)
+		createRet := td.ComputeInitActorExecReturn(alice, 0, 0, multisigAddr)
 		blkBuilder.WithTicketCount(1).
 			WithSECPMessageAndReceipt(
 				signMessage(
-					td.MessageProducer.CreateMultisigActor(aliceId,
-						[]address.Address{aliceId}, 10, 1,
-						chain.Nonce(0), chain.Value(big_spec.Zero()),
-					),
-					td.Wallet()), types.MessageReceipt{ExitCode: exitcode.Ok, ReturnValue: chain.MustSerialize(&createRet), GasUsed: abi_spec.NewTokenAmount(1282)},
+					td.MessageProducer.CreateMultisigActor(aliceId, []address.Address{aliceId}, 0, 1, chain.Nonce(0)),
+					td.Wallet()), types.MessageReceipt{ExitCode: exitcode.Ok, ReturnValue: chain.MustSerialize(&createRet), GasUsed: abi.NewTokenAmount(1282)},
 			).
 			WithSECPMessageAndReceipt(
 				signMessage(
-					td.MessageProducer.Build(multisigAddr, aliceId, builtin_spec.MethodsMultisig.Propose, proposeParams, chain.Nonce(1), chain.Value(big_spec.Zero())),
-					td.Wallet()),
-				types.MessageReceipt{ExitCode: exitcode.SysErrInvalidParameters, ReturnValue: drivers.EmptyReturnValue, GasUsed: abi_spec.NewTokenAmount(1235)},
+					td.MessageProducer.MultisigPropose(multisigAddr, aliceId, params, chain.Nonce(1)), td.Wallet()),
+				types.MessageReceipt{ExitCode: exitcode.SysErrInvalidParameters, ReturnValue: drivers.EmptyReturnValue, GasUsed: abi.NewTokenAmount(1235)},
 			).
 			ApplyAndValidate()
 
 		// the multisig txnid should increment and the 0th transaction should have been removed
-		var msa multisig_spec.State
+		var msa multisig.State
 		td.GetActorState(multisigAddr, &msa)
 		td.AssertMultisigContainsTransaction(multisigAddr, 0, false)
-		assert.Equal(t, multisig_spec.TxnID(1), msa.NextTxnID)
+		assert.Equal(t, multisig.TxnID(1), msa.NextTxnID)
 	})
 }

--- a/suites/validations.go
+++ b/suites/validations.go
@@ -16,6 +16,7 @@ func MessageTestCases() []TestCase {
 		message.TestInitActorSequentialIDAddressCreate,
 		message.TestMessageApplicationEdgecases,
 		message.TestMultiSigActor,
+		message.TestNestedSends,
 		message.TestPaych,
 		message.TestValueTransferAdvance,
 		message.TestValueTransferSimple,


### PR DESCRIPTION
I was debugging the internal message send tipset tests. I fixed some things wrong with the test, but still fails on go-filecoin. 

There's nothing inherently "tipset" about that test so I've set up a new message test file intending to replace it with vanilla message tests. But this cleanup and partial fix can go in now.