### PR TITLE
Apply Message Returns a Result structure

### DIFF
--- a/chain/types/receipt.go
+++ b/chain/types/receipt.go
@@ -15,6 +15,6 @@ type MessageReceipt struct {
 
 type GasUnits int64
 
-func (gu GasUnits) AsBigInt() big.Int {
+func (gu GasUnits) Big() big.Int {
 	return big.NewInt(int64(gu))
 }

--- a/chain/types/receipt.go
+++ b/chain/types/receipt.go
@@ -10,6 +10,11 @@ type MessageReceipt struct {
 	ExitCode    exitcode.ExitCode
 	ReturnValue []byte
 
-	// TODO make this an int64
-	GasUsed big.Int
+	GasUsed GasUnits
+}
+
+type GasUnits int64
+
+func (gu GasUnits) AsBigInt() big.Int {
+	return big.NewInt(int64(gu))
 }

--- a/chain/validator.go
+++ b/chain/validator.go
@@ -14,8 +14,8 @@ type Validator struct {
 
 type ApplyResult struct {
 	Receipt types.MessageReceipt
-	Penalty state.MinerPenaltyFIL
-	Reward  state.GasRewardFIL
+	Penalty abi.TokenAmount
+	Reward  abi.TokenAmount
 }
 
 // NewValidator builds a new validator.

--- a/chain/validator.go
+++ b/chain/validator.go
@@ -18,7 +18,7 @@ func NewValidator(executor state.Applier) *Validator {
 }
 
 // ApplyMessages applies a message to a state
-func (v *Validator) ApplyMessage(context *types.ExecutionContext, state state.VMWrapper, message *types.Message) (types.MessageReceipt, error) {
+func (v *Validator) ApplyMessage(context *types.ExecutionContext, state state.VMWrapper, message *types.Message) (types.MessageReceipt, state.MinerPenaltyFIL, state.GasRewardFIL, error) {
 	return v.applier.ApplyMessage(context, state, message)
 }
 

--- a/chain/validator.go
+++ b/chain/validator.go
@@ -12,14 +12,25 @@ type Validator struct {
 	applier state.Applier
 }
 
+type ApplyResult struct {
+	Receipt types.MessageReceipt
+	Penalty state.MinerPenaltyFIL
+	Reward  state.GasRewardFIL
+}
+
 // NewValidator builds a new validator.
 func NewValidator(executor state.Applier) *Validator {
 	return &Validator{executor}
 }
 
 // ApplyMessages applies a message to a state
-func (v *Validator) ApplyMessage(context *types.ExecutionContext, state state.VMWrapper, message *types.Message) (types.MessageReceipt, state.MinerPenaltyFIL, state.GasRewardFIL, error) {
-	return v.applier.ApplyMessage(context, state, message)
+func (v *Validator) ApplyMessage(context *types.ExecutionContext, state state.VMWrapper, message *types.Message) (ApplyResult, error) {
+	receipt, penalty, reward, err := v.applier.ApplyMessage(context, state, message)
+	return ApplyResult{
+		Receipt: receipt,
+		Penalty: penalty,
+		Reward:  reward,
+	}, err
 }
 
 func (v *Validator) ApplyTipSetMessages(epoch abi.ChainEpoch, state state.VMWrapper, blocks []types.BlockMessagesInfo, rnd state.RandomnessSource) ([]types.MessageReceipt, error) {

--- a/drivers/test.go
+++ b/drivers/test.go
@@ -329,7 +329,7 @@ func (td *TestDriver) applyMessageExpectCodeAndReturn(msg *types.Message, code e
 	if td.Config.ValidateGas() {
 		expectedGasUsed, ok := td.GasMeter.NextExpectedGas()
 		if ok {
-			assert.Equal(td.T, expectedGasUsed, result.Receipt.GasUsed.Int64(), "Expected GasUsed: %d Actual GasUsed: %d", expectedGasUsed, result.Receipt.GasUsed.Int64())
+			assert.Equal(td.T, expectedGasUsed, result.Receipt.GasUsed, "Expected GasUsed: %d Actual GasUsed: %d", expectedGasUsed, result.Receipt.GasUsed)
 		} else {
 			td.T.Logf("WARNING: failed to find expected gas cost for message: %+v", msg)
 		}

--- a/drivers/tipset_message_producer.go
+++ b/drivers/tipset_message_producer.go
@@ -61,7 +61,7 @@ func (t *TipSetMessageBuilder) ApplyAndValidate() {
 		if t.driver.Config.ValidateGas() {
 			expectedGas, found := t.driver.GasMeter.NextExpectedGas()
 			if found {
-				assert.Equal(t.driver.T, expectedGas, receipts[i].GasUsed.Int64(), "Message Number: %d Expected GasUsed: %s Actual GasUsed: %s", i, expectedGas, receipts[i].GasUsed.String())
+				assert.Equal(t.driver.T, expectedGas, receipts[i].GasUsed, "Message Number: %d Expected GasUsed: %s Actual GasUsed: %d", i, expectedGas, receipts[i].GasUsed)
 			} else {
 				t.driver.T.Logf("WARNING: failed to find expected gas cost for message number: %d", i)
 			}

--- a/gasmeter/gas_meter.go
+++ b/gasmeter/gas_meter.go
@@ -23,7 +23,7 @@ type trackerElement struct {
 }
 
 func (te *trackerElement) fileKey() string {
-	return fmt.Sprintf("%d", te.receipt.GasUsed.Int64())
+	return fmt.Sprintf("%d", te.receipt.GasUsed)
 }
 
 type GasMeter struct {

--- a/gasmeter/gas_meter.go
+++ b/gasmeter/gas_meter.go
@@ -51,13 +51,13 @@ func (gm *GasMeter) Track(receipt types.MessageReceipt) {
 	})
 }
 
-func (gm *GasMeter) NextExpectedGas() (int64, bool) {
+func (gm *GasMeter) NextExpectedGas() (types.GasUnits, bool) {
 	defer func() { gm.gasIdx += 1 }()
 	if gm.gasIdx > len(gm.expectedGasUnits)-1 {
 		// didn't find any gas
 		return 0, false
 	}
-	return gm.expectedGasUnits[gm.gasIdx], true
+	return types.GasUnits(gm.expectedGasUnits[gm.gasIdx]), true
 }
 
 // write the contents of gm.tracker to a file using the format:

--- a/state/applier.go
+++ b/state/applier.go
@@ -9,9 +9,12 @@ import (
 	"github.com/filecoin-project/chain-validation/chain/types"
 )
 
+type MinerPenaltyFIL = abi.TokenAmount
+type GasRewardFIL = abi.TokenAmount
+
 // Applier applies abstract messages to states.
 type Applier interface {
-	ApplyMessage(context *types.ExecutionContext, state VMWrapper, msg *types.Message) (types.MessageReceipt, error)
+	ApplyMessage(context *types.ExecutionContext, state VMWrapper, msg *types.Message) (types.MessageReceipt, MinerPenaltyFIL, GasRewardFIL, error)
 	ApplyTipSetMessages(state VMWrapper, blocks []types.BlockMessagesInfo, epoch abi.ChainEpoch, rnd RandomnessSource) ([]types.MessageReceipt, error)
 }
 

--- a/state/applier.go
+++ b/state/applier.go
@@ -9,12 +9,9 @@ import (
 	"github.com/filecoin-project/chain-validation/chain/types"
 )
 
-type MinerPenaltyFIL = abi.TokenAmount
-type GasRewardFIL = abi.TokenAmount
-
 // Applier applies abstract messages to states.
 type Applier interface {
-	ApplyMessage(context *types.ExecutionContext, state VMWrapper, msg *types.Message) (types.MessageReceipt, MinerPenaltyFIL, GasRewardFIL, error)
+	ApplyMessage(context *types.ExecutionContext, state VMWrapper, msg *types.Message) (types.MessageReceipt, abi.TokenAmount, abi.TokenAmount, error)
 	ApplyTipSetMessages(state VMWrapper, blocks []types.BlockMessagesInfo, epoch abi.ChainEpoch, rnd RandomnessSource) ([]types.MessageReceipt, error)
 }
 

--- a/suites/message/create_actor.go
+++ b/suites/message/create_actor.go
@@ -94,7 +94,7 @@ func TestAccountActorCreation(t *testing.T, factory state.Factories) {
 			// new actor balance will only exist if message was applied successfully.
 			if tc.expExitCode.IsSuccess() {
 				td.AssertBalance(tc.newActorAddr, tc.newActorInitBal)
-				td.AssertBalance(existingAccountAddr, big_spec.Sub(big_spec.Sub(tc.existingActorBal, result.Receipt.GasUsed), tc.newActorInitBal))
+				td.AssertBalance(existingAccountAddr, big_spec.Sub(big_spec.Sub(tc.existingActorBal, result.Receipt.GasUsed.AsBigInt()), tc.newActorInitBal))
 			}
 		})
 	}

--- a/suites/message/create_actor.go
+++ b/suites/message/create_actor.go
@@ -94,7 +94,7 @@ func TestAccountActorCreation(t *testing.T, factory state.Factories) {
 			// new actor balance will only exist if message was applied successfully.
 			if tc.expExitCode.IsSuccess() {
 				td.AssertBalance(tc.newActorAddr, tc.newActorInitBal)
-				td.AssertBalance(existingAccountAddr, big_spec.Sub(big_spec.Sub(tc.existingActorBal, result.Receipt.GasUsed.AsBigInt()), tc.newActorInitBal))
+				td.AssertBalance(existingAccountAddr, big_spec.Sub(big_spec.Sub(tc.existingActorBal, result.Receipt.GasUsed.Big()), tc.newActorInitBal))
 			}
 		})
 	}

--- a/suites/message/create_actor.go
+++ b/suites/message/create_actor.go
@@ -86,7 +86,7 @@ func TestAccountActorCreation(t *testing.T, factory state.Factories) {
 			defer td.Complete()
 
 			existingAccountAddr, _ := td.NewAccountActor(tc.existingActorType, tc.existingActorBal)
-			gasUsed := td.ApplyFailure(
+			result := td.ApplyFailure(
 				td.MessageProducer.Transfer(tc.newActorAddr, existingAccountAddr, chain.Value(tc.newActorInitBal), chain.Nonce(0)),
 				tc.expExitCode,
 			)
@@ -94,7 +94,7 @@ func TestAccountActorCreation(t *testing.T, factory state.Factories) {
 			// new actor balance will only exist if message was applied successfully.
 			if tc.expExitCode.IsSuccess() {
 				td.AssertBalance(tc.newActorAddr, tc.newActorInitBal)
-				td.AssertBalance(existingAccountAddr, big_spec.Sub(big_spec.Sub(tc.existingActorBal, big_spec.NewInt(gasUsed)), tc.newActorInitBal))
+				td.AssertBalance(existingAccountAddr, big_spec.Sub(big_spec.Sub(tc.existingActorBal, result.Receipt.GasUsed), tc.newActorInitBal))
 			}
 		})
 	}

--- a/suites/message/nested.go
+++ b/suites/message/nested.go
@@ -243,7 +243,7 @@ func prepareStage(td *drivers.TestDriver, creatorBalance, msBalance abi.TokenAmo
 	}
 }
 
-func (s *ms_stage) send(to address.Address, value abi.TokenAmount, method abi.MethodNum, params runtime.CBORMarshaler, approverNonce uint64) drivers.ApplyResult {
+func (s *ms_stage) send(to address.Address, value abi.TokenAmount, method abi.MethodNum, params runtime.CBORMarshaler, approverNonce uint64) chain.ApplyResult {
 	buf := bytes.Buffer{}
 	if params != nil {
 		err := params.MarshalCBOR(&buf)

--- a/suites/message/nested.go
+++ b/suites/message/nested.go
@@ -46,7 +46,7 @@ func TestNestedSends(t *testing.T, factory state.Factories) {
 		result := stage.send(stage.creator, amtSent, builtin.MethodSend, nil, 1)
 		assert.Equal(t, exitcode.Ok, result.Receipt.ExitCode)
 
-		td.AssertActor(stage.creator, big.Sub(big.Add(balanceBefore, amtSent), result.Receipt.GasUsed), 2)
+		td.AssertActor(stage.creator, big.Sub(big.Add(balanceBefore, amtSent), result.Receipt.GasUsed.AsBigInt()), 2)
 	})
 
 	t.Run("ok to new actor", func(t *testing.T) {
@@ -63,7 +63,7 @@ func TestNestedSends(t *testing.T, factory state.Factories) {
 		assert.Equal(t, exitcode.Ok, result.Receipt.ExitCode)
 
 		td.AssertBalance(stage.msAddr, big.Sub(multisigBalance, amtSent))
-		td.AssertBalance(stage.creator, big.Sub(balanceBefore, result.Receipt.GasUsed))
+		td.AssertBalance(stage.creator, big.Sub(balanceBefore, result.Receipt.GasUsed.AsBigInt()))
 		td.AssertBalance(newAddr, amtSent)
 	})
 
@@ -87,7 +87,7 @@ func TestNestedSends(t *testing.T, factory state.Factories) {
 		//assert.Equal(t, expected.Bytes(), result.Receipt.ReturnValue)
 
 		td.AssertBalance(stage.msAddr, big.Sub(multisigBalance, amtSent))
-		td.AssertBalance(stage.creator, big.Sub(balanceBefore, result.Receipt.GasUsed))
+		td.AssertBalance(stage.creator, big.Sub(balanceBefore, result.Receipt.GasUsed.AsBigInt()))
 		td.AssertBalance(newAddr, amtSent)
 	})
 
@@ -108,7 +108,7 @@ func TestNestedSends(t *testing.T, factory state.Factories) {
 		assert.Equal(t, exitcode.Ok, result.Receipt.ExitCode)
 
 		td.AssertBalance(stage.msAddr, multisigBalance)
-		assert.Equal(t, big.Sub(balanceBefore, result.Receipt.GasUsed), td.GetBalance(stage.creator))
+		assert.Equal(t, big.Sub(balanceBefore, result.Receipt.GasUsed.AsBigInt()), td.GetBalance(stage.creator))
 		var st multisig.State
 		td.GetActorState(stage.msAddr, &st)
 		assert.Equal(t, []address.Address{stage.creator, anotherId}, st.Signers)
@@ -206,8 +206,8 @@ func TestNestedSends(t *testing.T, factory state.Factories) {
 		result := stage.send(stage.creator, amtSent, abi.MethodNum(99), nil, 1)
 		assert.Equal(t, exitcode.Ok, result.Receipt.ExitCode)
 
-		td.AssertBalance(stage.msAddr, multisigBalance)                                 // No change.
-		td.AssertBalance(stage.creator, big.Sub(balanceBefore, result.Receipt.GasUsed)) // Pay gas, don't receive funds.
+		td.AssertBalance(stage.msAddr, multisigBalance)                                            // No change.
+		td.AssertBalance(stage.creator, big.Sub(balanceBefore, result.Receipt.GasUsed.AsBigInt())) // Pay gas, don't receive funds.
 	})
 
 	// TODO more tests:

--- a/suites/message/nested.go
+++ b/suites/message/nested.go
@@ -46,7 +46,7 @@ func TestNestedSends(t *testing.T, factory state.Factories) {
 		result := stage.send(stage.creator, amtSent, builtin.MethodSend, nil, 1)
 		assert.Equal(t, exitcode.Ok, result.Receipt.ExitCode)
 
-		td.AssertActor(stage.creator, big.Sub(big.Add(balanceBefore, amtSent), result.Receipt.GasUsed.AsBigInt()), 2)
+		td.AssertActor(stage.creator, big.Sub(big.Add(balanceBefore, amtSent), result.Receipt.GasUsed.Big()), 2)
 	})
 
 	t.Run("ok to new actor", func(t *testing.T) {
@@ -63,7 +63,7 @@ func TestNestedSends(t *testing.T, factory state.Factories) {
 		assert.Equal(t, exitcode.Ok, result.Receipt.ExitCode)
 
 		td.AssertBalance(stage.msAddr, big.Sub(multisigBalance, amtSent))
-		td.AssertBalance(stage.creator, big.Sub(balanceBefore, result.Receipt.GasUsed.AsBigInt()))
+		td.AssertBalance(stage.creator, big.Sub(balanceBefore, result.Receipt.GasUsed.Big()))
 		td.AssertBalance(newAddr, amtSent)
 	})
 
@@ -87,7 +87,7 @@ func TestNestedSends(t *testing.T, factory state.Factories) {
 		//assert.Equal(t, expected.Bytes(), result.Receipt.ReturnValue)
 
 		td.AssertBalance(stage.msAddr, big.Sub(multisigBalance, amtSent))
-		td.AssertBalance(stage.creator, big.Sub(balanceBefore, result.Receipt.GasUsed.AsBigInt()))
+		td.AssertBalance(stage.creator, big.Sub(balanceBefore, result.Receipt.GasUsed.Big()))
 		td.AssertBalance(newAddr, amtSent)
 	})
 
@@ -108,7 +108,7 @@ func TestNestedSends(t *testing.T, factory state.Factories) {
 		assert.Equal(t, exitcode.Ok, result.Receipt.ExitCode)
 
 		td.AssertBalance(stage.msAddr, multisigBalance)
-		assert.Equal(t, big.Sub(balanceBefore, result.Receipt.GasUsed.AsBigInt()), td.GetBalance(stage.creator))
+		assert.Equal(t, big.Sub(balanceBefore, result.Receipt.GasUsed.Big()), td.GetBalance(stage.creator))
 		var st multisig.State
 		td.GetActorState(stage.msAddr, &st)
 		assert.Equal(t, []address.Address{stage.creator, anotherId}, st.Signers)
@@ -206,8 +206,8 @@ func TestNestedSends(t *testing.T, factory state.Factories) {
 		result := stage.send(stage.creator, amtSent, abi.MethodNum(99), nil, 1)
 		assert.Equal(t, exitcode.Ok, result.Receipt.ExitCode)
 
-		td.AssertBalance(stage.msAddr, multisigBalance)                                            // No change.
-		td.AssertBalance(stage.creator, big.Sub(balanceBefore, result.Receipt.GasUsed.AsBigInt())) // Pay gas, don't receive funds.
+		td.AssertBalance(stage.msAddr, multisigBalance)                                       // No change.
+		td.AssertBalance(stage.creator, big.Sub(balanceBefore, result.Receipt.GasUsed.Big())) // Pay gas, don't receive funds.
 	})
 
 	// TODO more tests:

--- a/suites/message/paych.go
+++ b/suites/message/paych.go
@@ -137,7 +137,7 @@ func TestPaych(t *testing.T, factory state.Factories) {
 			td.MessageProducer.PaychCollect(paychAddr, receiver, adt_spec.EmptyValue{}, chain.Nonce(1), chain.Value(big_spec.Zero())))
 
 		// receiver_balance = initial_balance + paych_send - settle_paych_msg_gas - collect_paych_msg_gas
-		td.AssertBalance(receiver, big_spec.Sub(big_spec.Sub(big_spec.Add(toSend, initialBal), settleResult.Receipt.GasUsed), collectResult.Receipt.GasUsed))
+		td.AssertBalance(receiver, big_spec.Sub(big_spec.Sub(big_spec.Add(toSend, initialBal), settleResult.Receipt.GasUsed.AsBigInt()), collectResult.Receipt.GasUsed.AsBigInt()))
 		td.AssertBalance(paychAddr, big_spec.Zero())
 		var pcState paych_spec.State
 		td.GetActorState(paychAddr, &pcState)

--- a/suites/message/paych.go
+++ b/suites/message/paych.go
@@ -137,7 +137,7 @@ func TestPaych(t *testing.T, factory state.Factories) {
 			td.MessageProducer.PaychCollect(paychAddr, receiver, adt_spec.EmptyValue{}, chain.Nonce(1), chain.Value(big_spec.Zero())))
 
 		// receiver_balance = initial_balance + paych_send - settle_paych_msg_gas - collect_paych_msg_gas
-		td.AssertBalance(receiver, big_spec.Sub(big_spec.Sub(big_spec.Add(toSend, initialBal), settleResult.Receipt.GasUsed.AsBigInt()), collectResult.Receipt.GasUsed.AsBigInt()))
+		td.AssertBalance(receiver, big_spec.Sub(big_spec.Sub(big_spec.Add(toSend, initialBal), settleResult.Receipt.GasUsed.Big()), collectResult.Receipt.GasUsed.Big()))
 		td.AssertBalance(paychAddr, big_spec.Zero())
 		var pcState paych_spec.State
 		td.GetActorState(paychAddr, &pcState)

--- a/suites/message/paych.go
+++ b/suites/message/paych.go
@@ -127,17 +127,17 @@ func TestPaych(t *testing.T, factory state.Factories) {
 			}, chain.Nonce(1), chain.Value(big_spec.Zero())))
 
 		// settle the payment channel so it may be collected
-		settlePayChGasCost := td.ApplyOk(
+		settleResult := td.ApplyOk(
 			td.MessageProducer.PaychSettle(paychAddr, receiver, adt_spec.EmptyValue{}, chain.Value(big_spec.Zero()), chain.Nonce(0)))
 
 		// advance the epoch so the funds may be redeemed.
 		td.ExeCtx.Epoch++
 
-		collectPaychGasCost := td.ApplyOk(
+		collectResult := td.ApplyOk(
 			td.MessageProducer.PaychCollect(paychAddr, receiver, adt_spec.EmptyValue{}, chain.Nonce(1), chain.Value(big_spec.Zero())))
 
 		// receiver_balance = initial_balance + paych_send - settle_paych_msg_gas - collect_paych_msg_gas
-		td.AssertBalance(receiver, big_spec.Sub(big_spec.Sub(big_spec.Add(toSend, initialBal), abi_spec.NewTokenAmount(settlePayChGasCost)), abi_spec.NewTokenAmount(collectPaychGasCost)))
+		td.AssertBalance(receiver, big_spec.Sub(big_spec.Sub(big_spec.Add(toSend, initialBal), settleResult.Receipt.GasUsed), collectResult.Receipt.GasUsed))
 		td.AssertBalance(paychAddr, big_spec.Zero())
 		var pcState paych_spec.State
 		td.GetActorState(paychAddr, &pcState)

--- a/suites/message/transfer.go
+++ b/suites/message/transfer.go
@@ -121,7 +121,7 @@ func TestValueTransferSimple(t *testing.T, factories state.Factories) {
 			// create a message to transfer funds from `to` to `from` for amount `transferAmnt` and apply it to the state tree
 			// assert the actor balances changed as expected, the receiver balance should not change if transfer fails
 			if tc.code.IsSuccess() {
-				td.AssertBalance(tc.sender, big_spec.Sub(big_spec.Sub(tc.senderBal, tc.transferAmnt), result.Receipt.GasUsed.AsBigInt()))
+				td.AssertBalance(tc.sender, big_spec.Sub(big_spec.Sub(tc.senderBal, tc.transferAmnt), result.Receipt.GasUsed.Big()))
 				td.AssertBalance(tc.receiver, tc.transferAmnt)
 			} else {
 				td.AssertBalance(tc.sender, tc.senderBal)
@@ -148,7 +148,7 @@ func TestValueTransferAdvance(t *testing.T, factory state.Factories) {
 		result := td.ApplyOk(
 			td.MessageProducer.Transfer(alice, alice, chain.Value(transferAmnt), chain.Nonce(0)))
 		// since this is a self transfer expect alice's balance to only decrease by the gasUsed
-		td.AssertBalance(alice, big_spec.Sub(aliceInitialBalance, result.Receipt.GasUsed.AsBigInt()))
+		td.AssertBalance(alice, big_spec.Sub(aliceInitialBalance, result.Receipt.GasUsed.Big()))
 	})
 
 	t.Run("ok transfer from known address to new account", func(t *testing.T) {
@@ -162,7 +162,7 @@ func TestValueTransferAdvance(t *testing.T, factory state.Factories) {
 		result := td.ApplyOk(
 			td.MessageProducer.Transfer(receiver, alice, chain.Value(transferAmnt), chain.Nonce(0)),
 		)
-		td.AssertBalance(alice, big_spec.Sub(big_spec.Sub(aliceInitialBalance, result.Receipt.GasUsed.AsBigInt()), transferAmnt))
+		td.AssertBalance(alice, big_spec.Sub(big_spec.Sub(aliceInitialBalance, result.Receipt.GasUsed.Big()), transferAmnt))
 		td.AssertBalance(receiver, transferAmnt)
 	})
 

--- a/suites/message/transfer.go
+++ b/suites/message/transfer.go
@@ -121,7 +121,7 @@ func TestValueTransferSimple(t *testing.T, factories state.Factories) {
 			// create a message to transfer funds from `to` to `from` for amount `transferAmnt` and apply it to the state tree
 			// assert the actor balances changed as expected, the receiver balance should not change if transfer fails
 			if tc.code.IsSuccess() {
-				td.AssertBalance(tc.sender, big_spec.Sub(big_spec.Sub(tc.senderBal, tc.transferAmnt), result.Receipt.GasUsed))
+				td.AssertBalance(tc.sender, big_spec.Sub(big_spec.Sub(tc.senderBal, tc.transferAmnt), result.Receipt.GasUsed.AsBigInt()))
 				td.AssertBalance(tc.receiver, tc.transferAmnt)
 			} else {
 				td.AssertBalance(tc.sender, tc.senderBal)
@@ -148,7 +148,7 @@ func TestValueTransferAdvance(t *testing.T, factory state.Factories) {
 		result := td.ApplyOk(
 			td.MessageProducer.Transfer(alice, alice, chain.Value(transferAmnt), chain.Nonce(0)))
 		// since this is a self transfer expect alice's balance to only decrease by the gasUsed
-		td.AssertBalance(alice, big_spec.Sub(aliceInitialBalance, result.Receipt.GasUsed))
+		td.AssertBalance(alice, big_spec.Sub(aliceInitialBalance, result.Receipt.GasUsed.AsBigInt()))
 	})
 
 	t.Run("ok transfer from known address to new account", func(t *testing.T) {
@@ -162,7 +162,7 @@ func TestValueTransferAdvance(t *testing.T, factory state.Factories) {
 		result := td.ApplyOk(
 			td.MessageProducer.Transfer(receiver, alice, chain.Value(transferAmnt), chain.Nonce(0)),
 		)
-		td.AssertBalance(alice, big_spec.Sub(big_spec.Sub(aliceInitialBalance, result.Receipt.GasUsed), transferAmnt))
+		td.AssertBalance(alice, big_spec.Sub(big_spec.Sub(aliceInitialBalance, result.Receipt.GasUsed.AsBigInt()), transferAmnt))
 		td.AssertBalance(receiver, transferAmnt)
 	})
 

--- a/suites/tipset/rewards_penalties.go
+++ b/suites/tipset/rewards_penalties.go
@@ -62,9 +62,9 @@ func TestMinerRewardsAndPenalties(t *testing.T, factory state.Factories) {
 				tipB.Clear()
 
 				// Each account has paid gas fees.
-				td.AssertBalance(aliceId, big.Sub(aBal, rcpts[0].GasUsed))
-				td.AssertBalance(bobId, big.Sub(bBal, rcpts[1].GasUsed))
-				gasSum := big.Add(rcpts[0].GasUsed, rcpts[1].GasUsed) // Exploit gas price = 1
+				td.AssertBalance(aliceId, big.Sub(aBal, rcpts[0].GasUsed.AsBigInt()))
+				td.AssertBalance(bobId, big.Sub(bBal, rcpts[1].GasUsed.AsBigInt()))
+				gasSum := big.Add(rcpts[0].GasUsed.AsBigInt(), rcpts[1].GasUsed.AsBigInt()) // Exploit gas price = 1
 
 				// Validate rewards.
 				// No reward is paid to the miner directly. The funds for block reward were already held by the

--- a/suites/tipset/rewards_penalties.go
+++ b/suites/tipset/rewards_penalties.go
@@ -62,9 +62,9 @@ func TestMinerRewardsAndPenalties(t *testing.T, factory state.Factories) {
 				tipB.Clear()
 
 				// Each account has paid gas fees.
-				td.AssertBalance(aliceId, big.Sub(aBal, rcpts[0].GasUsed.AsBigInt()))
-				td.AssertBalance(bobId, big.Sub(bBal, rcpts[1].GasUsed.AsBigInt()))
-				gasSum := big.Add(rcpts[0].GasUsed.AsBigInt(), rcpts[1].GasUsed.AsBigInt()) // Exploit gas price = 1
+				td.AssertBalance(aliceId, big.Sub(aBal, rcpts[0].GasUsed.Big()))
+				td.AssertBalance(bobId, big.Sub(bBal, rcpts[1].GasUsed.Big()))
+				gasSum := big.Add(rcpts[0].GasUsed.Big(), rcpts[1].GasUsed.Big()) // Exploit gas price = 1
 
 				// Validate rewards.
 				// No reward is paid to the miner directly. The funds for block reward were already held by the


### PR DESCRIPTION
Two things happening here:
1. ApplyMessage returns a result structure containing the message receipt, miner penalty, and gas reward 
2. Message Receipt GasUsed is type GasUnits (int64 alias) with a method `AsBigInt()` since it is almost exclusively compared against bigints.  

In a follow on `ApplyResult` could be extended to contain previous and current state CID's as well as other relevant information.