### PR TITLE
add undecodable params during inner send

### DIFF
--- a/chain/puppet.go
+++ b/chain/puppet.go
@@ -16,3 +16,7 @@ func (mp *MessageProducer) PuppetSend(from, to address.Address, params *puppet.S
 	ser := MustSerialize(params)
 	return mp.Build(from, to, puppet.MethodsPuppet.Send, ser, opts...)
 }
+func (mp *MessageProducer) PuppetSendMarshalCBORFailure(to, from address.Address, params *puppet.SendParams, opts ...MsgOpt) *types.Message {
+	ser := MustSerialize(params)
+	return mp.Build(to, from, puppet.MethodsPuppet.SendMarshalCBORFailuer, ser, opts...)
+}

--- a/chain/puppet.go
+++ b/chain/puppet.go
@@ -18,5 +18,5 @@ func (mp *MessageProducer) PuppetSend(from, to address.Address, params *puppet.S
 }
 func (mp *MessageProducer) PuppetSendMarshalCBORFailure(to, from address.Address, params *puppet.SendParams, opts ...MsgOpt) *types.Message {
 	ser := MustSerialize(params)
-	return mp.Build(to, from, puppet.MethodsPuppet.SendMarshalCBORFailuer, ser, opts...)
+	return mp.Build(to, from, puppet.MethodsPuppet.SendMarshalCBORFailure, ser, opts...)
 }

--- a/suites/message/message_application.go
+++ b/suites/message/message_application.go
@@ -8,7 +8,6 @@ import (
 	big_spec "github.com/filecoin-project/specs-actors/actors/abi/big"
 	paych_spec "github.com/filecoin-project/specs-actors/actors/builtin/paych"
 	crypto_spec "github.com/filecoin-project/specs-actors/actors/crypto"
-
 	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
 
 	"github.com/filecoin-project/chain-validation/chain"


### PR DESCRIPTION
- uses puppet actor
- doesn't have resources generated yet since both lotus and go-filecoin fail (need conformation this test is correct)

Lotus fails applying both messages with error code: `SysErrInsufficientFunds`, it never reaches the internal send. This appears to be wrong.
https://github.com/filecoin-project/lotus/blob/master/chain/vm/runtime.go#L352

go-filecoin passes the first message application and panics on applying the second message.